### PR TITLE
Runbot Agressive Janitor

### DIFF
--- a/runbot_janitor/__init__.py
+++ b/runbot_janitor/__init__.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models

--- a/runbot_janitor/__openerp__.py
+++ b/runbot_janitor/__openerp__.py
@@ -1,0 +1,53 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+{
+    'name': 'Runbot Janitor',
+    'category': 'Website',
+    'summary': 'Aggressively clean filesystem databases and processes',
+    'version': '1.0',
+    'description': """
+Runbot Janitor
+==============
+
+Aggressively clean filesystem databases and processes
+Start a cron which will look in runbot's build directories
+(runbot/static/build) and identify all build directories which have no running
+builds (runbot.build).
+
+Using the names of these directories, cleanup by:
+  * killing processes which run executables in those directories or are
+    connected to databases matching the directory names
+  * drop all databases whose names match the directory names
+  * delete the directory and its contents
+
+Contributors
+------------
+* Sandy Carter (sandy.carter@savoirfairelinux.com)
+* Jordi Riera (jordi.riera@savoirfairelinux.com)
+""",
+    'author': 'Savoir-faire Linux',
+    'depends': ['runbot'],
+    'data': [
+    ],
+    'installable': True,
+}

--- a/runbot_janitor/models/__init__.py
+++ b/runbot_janitor/models/__init__.py
@@ -1,0 +1,23 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from . import runbot_repo

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -173,9 +173,13 @@ class RunbotRepo(models.Model):
         pattern_path = os.path.join(self.root(), 'build', pattern)
         log_dir = os.path.join(pattern_path, 'logs')
         if os.path.isdir(log_dir) and os.listdir(log_dir):
-            for directory in os.listdir(pattern_path):
-                if directory == 'logs':
+            for name in os.listdir(pattern_path):
+                path = os.path.join(pattern_path, name)
+                if name == 'logs':
                     continue
-                shutil.rmtree(directory)
+                if os.path.isdir(path)
+                        shutil.rmtree(path)
+                else:
+                    os.unlink(path)
         else:
             shutil.rmtree(pattern_path)

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -177,7 +177,7 @@ class RunbotRepo(models.Model):
                 path = os.path.join(pattern_path, name)
                 if name == 'logs':
                     continue
-                if os.path.isdir(path)
+                if os.path.isdir(path):
                         shutil.rmtree(path)
                 else:
                     os.unlink(path)

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -72,6 +72,7 @@ class RunbotRepo(models.Model):
         super(RunbotRepo, self).__init__(pool, cr)
         runbot_build = pool['runbot.build']
         ids = pool['runbot.build'].search(cr, SUPERUSER_ID, [])
+        _logger.info('marking %d builds as done', len(ids))
         runbot_build.write(cr, SUPERUSER_ID, ids, {'state': 'done'})
 
     @api.model

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -103,15 +103,15 @@ class RunbotRepo(models.Model):
             try:
                 self.clean_up_database(pattern)
             except OSError as e:
-                _logger.error(e)
+                _logger.error('Error in database cleanup: %s', e)
             try:
                 self.clean_up_process(pattern)
             except OSError as e:
-                _logger.error(e)
+                _logger.error('Error in process cleanup: %s', e)
             try:
                 self.clean_up_filesystem(pattern)
             except OSError as e:
-                _logger.error(e)
+                _logger.error('Error in file system cleanup: %s', e)
 
     def clean_up_pids(self):
         """Kill all done pids which are still running

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -113,18 +113,8 @@ class RunbotRepo(models.Model):
                 _logger.error(e)
 
     def clean_up_pids(self):
-        """Check if builds have pids registered which are no longer running
-
-        Mark those as done
-        Kill all done pids
+        """Kill all done pids which are still running
         """
-        # Mark build with non-running pids as done
-        self.env['runbot.build'].search([
-            ('pid', '!=', False),
-            ('pid', 'not in', psutil.pids()),
-            ('state', '!=', 'done')
-        ]).write({'state': 'done'})
-        # Kill still running pids
         for build in self.env['runbot.build'].search([
             ('pid', 'in', psutil.pids()),
             ('state', '=', 'done')

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -123,7 +123,8 @@ class RunbotRepo(models.Model):
             _logger.debug("Killing pid %s" % build.pid)
             try:
                 os.kill(build.pid, signal.SIGKILL)
-            finally:
+            except OSError, exc:
+                _logger.warning('Could not kill pid %d: %s', build.pid, exc)
                 build.pid = False
 
     def clean_up_database(self, pattern):

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -21,6 +21,7 @@
 ##############################################################################
 
 import os
+import shutil
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -85,4 +86,5 @@ class RunbotRepo(models.Model):
 
         :param pattern: string
         """
-        pass
+        pattern_path = os.path.join(self.root(), 'build', pattern)
+        shutil.rmtree(pattern_path)

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -96,10 +96,10 @@ class RunbotRepo(models.Model):
             ('dest', 'in', list(build_dirs)),
             ('state', '!=', 'done')
         ])]
-        _logger.debug("build_dirs = %s" % build_dirs)
-        _logger.debug("valid_builds = %s" % valid_builds)
+        _logger.debug("build_dirs = %s", build_dirs)
+        _logger.debug("valid_builds = %s", valid_builds)
         for pattern in build_dirs.difference(valid_builds):
-            _logger.info("Runbot Janitor Cleaning up Residue: %s" % pattern)
+            _logger.info("Runbot Janitor Cleaning up Residue: %s", pattern)
             try:
                 self.clean_up_database(pattern)
             except OSError as e:
@@ -120,7 +120,7 @@ class RunbotRepo(models.Model):
             ('pid', 'in', psutil.pids()),
             ('state', '=', 'done')
         ]):
-            _logger.debug("Killing pid %s" % build.pid)
+            _logger.debug("Killing pid %s", build.pid)
             try:
                 os.kill(build.pid, signal.SIGKILL)
             except OSError, exc:
@@ -138,7 +138,7 @@ class RunbotRepo(models.Model):
         db_list = exp_list_posix_user()
         time.sleep(1)  # Give time for the cursor to close properly
         for db_name in filter(regex.match, db_list):
-            _logger.debug("Dropping %s" % db_name)
+            _logger.debug("Dropping %s", db_name)
             runbot_build.pg_dropdb(dbname=db_name)
 
     def clean_up_process(self, pattern):
@@ -151,7 +151,7 @@ class RunbotRepo(models.Model):
         regex = re.compile(r'.*-d {}.*'.format(pattern))
         for process in psutil.process_iter():
             if regex.match(" ".join(process.cmdline())):
-                _logger.debug("Killing pid %s" % process.pid)
+                _logger.debug("Killing pid %s", process.pid)
                 process.kill()
 
     def clean_up_filesystem(self, pattern):

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -84,9 +84,12 @@ class RunbotRepo(models.Model):
         call the cleans: filesystem, database, process
 
         Leftover builds will have state done
+        Skip if the build directory hasn't been created yet
         """
         self.clean_up_pids()
         build_root = os.path.join(self.root(), 'build')
+        if not os.path.exists(build_root):
+            return
         build_dirs = set(os.listdir(build_root))
         valid_builds = [b.dest for b in self.env['runbot.build'].search([
             ('dest', 'in', list(build_dirs)),

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -1,0 +1,70 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import logging
+_logger = logging.getLogger(__name__)
+
+from openerp import models, api
+
+
+class RunbotRepo(models.Model):
+    """Aggressively clean filesystem databases and processes."""
+    _inherit = "runbot.repo"
+
+    @api.model
+    def cron(self):
+        """Overcharge cron, add clean up subroutine before the general cron."""
+        self.clean_up()
+        return super(RunbotRepo, self).cron()
+
+    def clean_up(self):
+        """Examines the build directory, identify leftover builds then
+        call the cleans: filesystem, database, process
+        """
+        pattern = ""
+        self.clean_up_database(pattern)
+        self.clean_up_process(pattern)
+        self.clean_up_filesystem(pattern)
+
+    def clean_up_database(self, pattern):
+        """Drop all databases whose names match the directory names matching
+        the pattern.
+
+        :param pattern:string
+        """
+        pass
+
+    def clean_up_process(self, pattern):
+        """Kill processes which run executables in those directories or are
+        connected to databases matching the directory names matching
+        the pattern.
+
+        :param pattern: string
+        """
+        pass
+
+    def clean_up_filesystem(self, pattern):
+        """Delete the directory and its contents matching the pattern.
+
+        :param pattern: string
+        """
+        pass

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -99,9 +99,18 @@ class RunbotRepo(models.Model):
         _logger.debug("valid_builds = %s" % valid_builds)
         for pattern in build_dirs.difference(valid_builds):
             _logger.info("Runbot Janitor Cleaning up Residue: %s" % pattern)
-            self.clean_up_database(pattern)
-            self.clean_up_process(pattern)
-            self.clean_up_filesystem(pattern)
+            try:
+                self.clean_up_database(pattern)
+            except OSError as e:
+                _logger.error(e)
+            try:
+                self.clean_up_process(pattern)
+            except OSError as e:
+                _logger.error(e)
+            try:
+                self.clean_up_filesystem(pattern)
+            except OSError as e:
+                _logger.error(e)
 
     def clean_up_pids(self):
         """Check if builds have pids registered which are no longer running

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -71,7 +71,7 @@ class RunbotRepo(models.Model):
         """On reinitialisation of db, mark all builds as done"""
         super(RunbotRepo, self).__init__(pool, cr)
         runbot_build = pool['runbot.build']
-        ids = pool['runbot.build'].search(cr, SUPERUSER_ID, [])
+        ids = pool['runbot.build'].search(cr, SUPERUSER_ID, [('state', '!=', 'done')])
         _logger.info('marking %d builds as done', len(ids))
         runbot_build.write(cr, SUPERUSER_ID, ids, {'state': 'done'})
 

--- a/runbot_janitor/models/runbot_repo.py
+++ b/runbot_janitor/models/runbot_repo.py
@@ -32,6 +32,7 @@ from contextlib import closing
 
 import logging
 _logger = logging.getLogger(__name__)
+_logger.setLevel(logging.DEBUG)
 
 from openerp import models, api, SUPERUSER_ID, tools, sql_db
 
@@ -155,7 +156,16 @@ class RunbotRepo(models.Model):
     def clean_up_filesystem(self, pattern):
         """Delete the directory and its contents matching the pattern.
 
+        If there are logs, delete everything except those
+
         :param pattern: string
         """
         pattern_path = os.path.join(self.root(), 'build', pattern)
-        shutil.rmtree(pattern_path)
+        log_dir = os.path.join(pattern_path, 'logs')
+        if os.path.isdir(log_dir) and os.listdir(log_dir):
+            for directory in os.listdir(pattern_path):
+                if directory == 'logs':
+                    continue
+                shutil.rmtree(directory)
+        else:
+            shutil.rmtree(pattern_path)

--- a/runbot_janitor/tests/__init__.py
+++ b/runbot_janitor/tests/__init__.py
@@ -1,0 +1,22 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import test_runbot_repo

--- a/runbot_janitor/tests/test_runbot_repo.py
+++ b/runbot_janitor/tests/test_runbot_repo.py
@@ -1,0 +1,99 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, Open Source Management Solution
+#    This module copyright (C) 2010 - 2014 Savoir-faire Linux
+#    (<http://www.savoirfairelinux.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+import os
+import shutil
+import tempfile
+import subprocess
+import sys
+
+import logging
+_logger = logging.getLogger(__name__)
+
+from openerp.tests import TransactionCase
+
+
+class TestRunbotRepo(TransactionCase):
+    """Aggressively clean filesystem databases and processes."""
+
+    def setUp(self):
+        """
+        Create a temp build dir with a python file in it
+        Run a process from inside build dir
+        Create a database with similar name to temp build dir
+        """
+        super(TestRunbotRepo, self).setUp()
+        self.runbot_repo = self.env['runbot.repo']
+        self.runbot_build = self.env['runbot.build']
+
+        # Filesystem
+        self.root = os.path.join(self.runbot_repo.root(), 'build')
+        self.build_dir = tempfile.mkdtemp(dir=self.root)
+        self.build_basename = os.path.basename(self.build_dir)
+        self.build_file_handle = tempfile.mkstemp(
+            suffix=".py", dir=self.build_dir
+        )
+
+        # Database
+        self.base_database = self.build_basename + "-base"
+        self.all_database = self.build_basename + "-all"
+        self.runbot_build.pg_createdb(dbname=self.base_database)
+        self.runbot_build.pg_createdb(dbname=self.all_database)
+
+        # Process
+        self.build_filename = self.build_file_handle[1]
+        with open(self.build_filename, 'w') as f:
+            f.write("from time import sleep; sleep(60)")
+        os.chmod(self.build_filename, 0o111)
+        self.process = subprocess.Popen([sys.executable, self.build_filename])
+
+    def tearDown(self):
+        """Delete temp build dir, kill process and drop database"""
+        self.process.kill()
+        if os.path.isdir(self.build_dir):
+            shutil.rmtree(self.build_dir)
+        # Database
+        self.runbot_build.pg_dropdb(dbname=self.build_basename + "-base")
+        self.runbot_build.pg_dropdb(dbname=self.build_basename + "-all")
+
+    def test_clean_up_process(self):
+        """Kill processes which run executables in those directories or are
+        connected to databases matching the directory names matching
+        the pattern.
+
+        :param pattern: string
+        """
+        pass
+
+    def test_clean_up_database(self):
+        """Drop all databases whose names match the directory names matching
+        the pattern.
+
+        :param pattern:string
+        """
+        pass
+
+    def test_clean_up_filesystem(self):
+        """Delete the directory and its contents matching the pattern.
+
+        :param pattern: string
+        """
+        pass

--- a/runbot_janitor/tests/test_runbot_repo.py
+++ b/runbot_janitor/tests/test_runbot_repo.py
@@ -96,4 +96,6 @@ class TestRunbotRepo(TransactionCase):
 
         :param pattern: string
         """
-        pass
+        self.assertTrue(os.path.isdir(self.build_dir))
+        self.runbot_repo.clean_up_filesystem(self.build_basename)
+        self.assertFalse(os.path.isdir(self.build_dir))

--- a/runbot_janitor/tests/test_runbot_repo.py
+++ b/runbot_janitor/tests/test_runbot_repo.py
@@ -29,6 +29,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 from openerp.tests import TransactionCase
+from ..models.runbot_repo import exp_list_posix_user
 
 
 class TestRunbotRepo(TransactionCase):
@@ -89,7 +90,17 @@ class TestRunbotRepo(TransactionCase):
 
         :param pattern:string
         """
-        pass
+        db_list = exp_list_posix_user()
+        self.assertIn(self.base_database, db_list)
+        self.assertIn(self.all_database, db_list)
+
+        # cleaning all the test database
+        self.runbot_repo.clean_up_database(self.build_basename)
+
+        # Need to refresh the db list
+        db_list = exp_list_posix_user()
+        self.assertNotIn(self.base_database, db_list)
+        self.assertNotIn(self.all_database, db_list)
 
     def test_clean_up_filesystem(self):
         """Delete the directory and its contents matching the pattern.

--- a/runbot_janitor/tests/test_runbot_repo.py
+++ b/runbot_janitor/tests/test_runbot_repo.py
@@ -49,6 +49,8 @@ class TestRunbotRepo(TransactionCase):
 
         # Filesystem
         self.root = os.path.join(self.runbot_repo.root(), 'build')
+        if not os.path.exists(self.root):
+            os.mkdir(self.root)
         self.build_dir = tempfile.mkdtemp(dir=self.root)
         self.build_basename = os.path.basename(self.build_dir)
         self.build_file_handle = tempfile.mkstemp(


### PR DESCRIPTION
This is a module whose aim is to save space and processing power

It checks the runbot build directory for old builds.
It checks by looking at running builds and comparing the with the contents of the build directory. Any extra builds are removed along with associated databases.
It will also do it's best at kill processes which are orphaned.

Additionally, it sets all builds as done when starting up: A big issue with runbot is that when restarting the server, the build objects are still marked as running when they're clearly not.

Credit to @foutoucour who helped out with the implementation, especially the tests.
