### PR TITLE
Avoid TransactionRollback by autocommiting

### DIFF
--- a/runbot_gitlab/runbot_repo.py
+++ b/runbot_gitlab/runbot_repo.py
@@ -221,6 +221,9 @@ class RunbotRepo(models.Model):
 
         super(RunbotRepo, self).update()
 
+        # Avoid TransactionRollbackError due to serialization issues
+        self._cr.autocommit(True)
+
         # Put all protected branches as sticky
         protected_branches = set(
             b.name for b in project.find_branch(find_all=True, protected=True)


### PR DESCRIPTION
Since cron runs for so long `build.skip()` was having concurrent update issues (`TransactionRollback`).
Setting `autocommit` fixes this
