### PR TITLE
Remove excess modules from odoo-extra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ install:
   - pip install gitlab3
   - travis_install_nightly
   - git clone --depth=1 https://github.com/odoo/odoo-extra ~/odoo-extra
+  # odoo-extra has a bunch of v9 modules which aren't compatible, remove them
+  - rm -rf $(ls | grep -v runbot$)
 
 script:
   - travis_run_tests


### PR DESCRIPTION
Prevent errors such as`ImportError: cannot import name UserError` which apear to be v9 syntax
