### PR TITLE
allow to pass on another repository and database name to custom script

### DIFF
--- a/runbot_build_instructions/README.rst
+++ b/runbot_build_instructions/README.rst
@@ -1,0 +1,66 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+    :alt: License: AGPL-3
+
+Runbot Custom Build and Run Instructions
+========================================
+
+Runbot with custom build instructions.
+This is useful for custom installation and deployment scripts such as buildout.
+
+Configuration
+=============
+
+This module adds an option in Repository form view for custom builds. When
+checked:
+
+* Modules to test becomes required attribute.
+* Custom build directory can be specified. This is where the repo will be
+  cloned in the build directory.
+* Custom server path is required to be specified. This is tells runbot which
+  executable script to run.
+* Custom server flags can be specified to add to execution. E.g. --workers=0
+* Pre-build commands can be run such as additional fetch scripts or buildout.
+* An alternate repository can be specified, and then passed on to the custom
+  build commands. A practical example of that is passing on a repository
+  containing a clone of odoo to the custom build script. That script can for
+  example make a local clone of odoo, saving both time and disk space.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/146/8.0
+
+For further information, please visit:
+
+* https://www.odoo.com/forum/help-1
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/OCA/{project_repo}/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+`here <https://github.com/OCA/runbot-addons/issues/new?body=module:%20runbot_build_instructions%0Aversion:%208.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+
+Credits
+=======
+
+Contributors
+------------
+* Sandy Carter (sandy.carter@savoirfairelinux.com)
+* Leonardo Pistone (leonardo.pistone@camptocamp.com)
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/runbot_build_instructions/__openerp__.py
+++ b/runbot_build_instructions/__openerp__.py
@@ -24,28 +24,7 @@
     'name': 'Runbot Custom Build and Run Instructions',
     'category': 'Website',
     'summary': 'Runbot with custom build and run instructions',
-    'version': '1.1',
-    'description': """
-Runbot Custom Build and Run Instructions
-========================================
-
-Runbot with custom build instructions.
-This is useful for custom installation and deployment scripts such as buildout.
-
-Add option in repo form view for custom builds. When checked:
-
-* Modules to test becomes required attribute.
-* Custom build directory can be specified. This is where the repo will be
-  cloned in the build directory.
-* Custom server path is required to be specified. This is tells runbot which
-  executable script to run.
-* Custom server flags can be specified to add to execution. E.g. --workers=0
-* Pre-build commands can be run such as additional fetch scripts or buildout.
-
-Contributors
-------------
-* Sandy Carter (sandy.carter@savoirfairelinux.com)
-""",
+    'version': '1.2',
     'author': "Savoir-faire Linux,Odoo Community Association (OCA)",
     'depends': ['runbot'],
     'data': [

--- a/runbot_build_instructions/runbot_build.py
+++ b/runbot_build_instructions/runbot_build.py
@@ -77,6 +77,7 @@ class runbot_build(orm.Model):
         internal_vals = {
             'custom_build_dir': build.repo_id.custom_build_dir or '',
             'custom_server_path': build.repo_id.custom_server_path,
+            'other_repo_path': build.repo_id.other_repo_id.path or '',
         }
         return [i % internal_vals for i in cmd]
 

--- a/runbot_build_instructions/runbot_build.py
+++ b/runbot_build_instructions/runbot_build.py
@@ -78,6 +78,7 @@ class runbot_build(orm.Model):
             'custom_build_dir': build.repo_id.custom_build_dir or '',
             'custom_server_path': build.repo_id.custom_server_path,
             'other_repo_path': build.repo_id.other_repo_id.path or '',
+            'build_dest': build.dest,
         }
         return [i % internal_vals for i in cmd]
 

--- a/runbot_build_instructions/runbot_repo.py
+++ b/runbot_build_instructions/runbot_repo.py
@@ -25,6 +25,13 @@ from openerp import fields, models
 
 _logger = logging.getLogger(__name__)
 
+ARGUMENTS_HELP = """\
+- Use %(custom_build_dir)s for relative custom build directory.
+- Use %(custom_server_path)s for relative custom server path.
+- Use %(other_repo_path)s for the path of the other repo.
+- Use %(build_dest)s for the build_dest code, used for example to build the \
+database name."""
+
 
 class RunbotRepo(models.Model):
     _inherit = "runbot.repo"
@@ -39,24 +46,11 @@ class RunbotRepo(models.Model):
     )
     custom_server_params = fields.Char(
         'Custom Server Flags',
-        help="""\
-Arguments to add to the Odoo script
-- Use %(custom_build_dir)s for relative custom build directory.
-- Use %(custom_server_path)s for relative custom server path.
-- Use %(other_repo_path)s for the path of the other repo.
-- Use %(build_dest)s for the build_dest code, used for example to build the \
-database name.
-""",
+        help=ARGUMENTS_HELP,
     )
     custom_pre_build_cmd = fields.Char(
         'Custom Pre-build Command',
-        help="""\
-- Use %(custom_build_dir)s for relative custom build directory.
-- Use %(custom_server_path)s for relative custom server path.
-- Use %(other_repo_path)s for the path of the other repo.
-- Use %(build_dest)s for the build_dest code, used for example to build the \
-database name.
-""",
+        help=ARGUMENTS_HELP,
     )
     other_repo_id = fields.Many2one(
         'runbot.repo',

--- a/runbot_build_instructions/runbot_repo.py
+++ b/runbot_build_instructions/runbot_repo.py
@@ -44,6 +44,8 @@ Arguments to add to the Odoo script
 - Use %(custom_build_dir)s for relative custom build directory.
 - Use %(custom_server_path)s for relative custom server path.
 - Use %(other_repo_path)s for the path of the other repo.
+- Use %(build_dest)s for the build_dest code, used for example to build the \
+database name.
 """,
     )
     custom_pre_build_cmd = fields.Char(
@@ -52,6 +54,8 @@ Arguments to add to the Odoo script
 - Use %(custom_build_dir)s for relative custom build directory.
 - Use %(custom_server_path)s for relative custom server path.
 - Use %(other_repo_path)s for the path of the other repo.
+- Use %(build_dest)s for the build_dest code, used for example to build the \
+database name.
 """,
     )
     other_repo_id = fields.Many2one(

--- a/runbot_build_instructions/runbot_repo.py
+++ b/runbot_build_instructions/runbot_repo.py
@@ -43,6 +43,7 @@ class RunbotRepo(models.Model):
 Arguments to add to the Odoo script
 - Use %(custom_build_dir)s for relative custom build directory.
 - Use %(custom_server_path)s for relative custom server path.
+- Use %(other_repo_path)s for the path of the other repo.
 """,
     )
     custom_pre_build_cmd = fields.Char(
@@ -50,5 +51,12 @@ Arguments to add to the Odoo script
         help="""\
 - Use %(custom_build_dir)s for relative custom build directory.
 - Use %(custom_server_path)s for relative custom server path.
+- Use %(other_repo_path)s for the path of the other repo.
 """,
+    )
+    other_repo_id = fields.Many2one(
+        'runbot.repo',
+        'Other repository',
+        help='Specify a secondary repository whose path can be passed to the '
+        'build commands.',
     )

--- a/runbot_build_instructions/runbot_repo_view.xml
+++ b/runbot_build_instructions/runbot_repo_view.xml
@@ -16,6 +16,7 @@
             <field name="custom_server_path" attrs="{'invisible': [('is_custom_build', '=', False)], 'required': [('is_custom_build', '=', True)]}"/>
             <field name="custom_server_params" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="custom_pre_build_cmd" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
+            <field name="other_repo_id" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
           </group>
         </group>
       </field>


### PR DESCRIPTION
The path to the other repo can be passed on to the custom build script.
For example, this can used to tell a buildout to make a local clone of
odoo instead of cloning everything every time.
