### PR TITLE
[FIX] Calling branch method of gitlab API without name kwarg

### DIFF
--- a/runbot_gitlab/runbot_repo.py
+++ b/runbot_gitlab/runbot_repo.py
@@ -201,7 +201,7 @@ class RunbotRepo(models.Model):
             source_project = get_gitlab_project(
                 self.base, self.token, mr.source_project_id
             )
-            source_branch = source_project.branch(name=mr.source_branch)
+            source_branch = source_project.branch(mr.source_branch)
             commit = source_branch.commit
             sha = commit['id']
             date = commit['committed_date']


### PR DESCRIPTION
Calling branch method of the Gitlab Project with keyword argument name fails to retrieve branch info

Issue was also referenced by other users and the fix seemed to work https://github.com/OCA/runbot-addons/issues/61#issuecomment-136794670

Method definition in API class:

https://github.com/alexvh/python-gitlab3/blob/master/gitlab3/_api_definition.py#L257
