### PR TITLE
[IMP] Add translations folder and two extra boolean fields to runbot_gitlab

### DIFF
--- a/runbot_gitlab/__openerp__.py
+++ b/runbot_gitlab/__openerp__.py
@@ -36,6 +36,7 @@ Add option in repo form view for gitlab repos builds. When checked:
 Contributors
 ------------
 * Sandy Carter (sandy.carter@savoirfairelinux.com)
+* Paul Catinean (paulcatinean@gmail.com)
 """,
     'author': "Savoir-faire Linux,Odoo Community Association (OCA)",
     'depends': ['runbot'],

--- a/runbot_gitlab/i18n/runbot_gitlab.pot
+++ b/runbot_gitlab/i18n/runbot_gitlab.pot
@@ -1,0 +1,92 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* runbot_gitlab
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-09-03 07:35+0000\n"
+"PO-Revision-Date: 2015-09-03 07:35+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: runbot_gitlab
+#: view:runbot.repo:runbot_gitlab.view_repo_form
+msgid "API Token"
+msgstr ""
+
+#. module: runbot_gitlab
+#: help:runbot.repo,mr_only:0
+msgid "Build only merge requests and skip regular branches"
+msgstr ""
+
+#. module: runbot_gitlab
+#: code:addons/runbot_gitlab/runbot_repo.py:122
+#, python-format
+msgid "Could not find repo with "
+msgstr ""
+
+#. module: runbot_gitlab
+#: code:addons/runbot_gitlab/runbot_repo.py:131
+#, python-format
+msgid "Error!"
+msgstr ""
+
+#. module: runbot_gitlab
+#: view:runbot.repo:runbot_gitlab.view_repo_form
+msgid "Gitlab"
+msgstr ""
+
+#. module: runbot_gitlab
+#: code:addons/runbot_gitlab/runbot_repo.py:132
+#, python-format
+msgid "Gitlab repo requires an API token from a user with admin access to repo."
+msgstr ""
+
+#. module: runbot_gitlab
+#: field:runbot.repo,mr_only:0
+msgid "MR Only"
+msgstr ""
+
+#. module: runbot_gitlab
+#: field:runbot.branch,merge_request_id:0
+msgid "Merge Request"
+msgstr ""
+
+#. module: runbot_gitlab
+#: help:runbot.repo,sticky_protected:0
+msgid "Set all protected branches on the repository as sticky"
+msgstr ""
+
+#. module: runbot_gitlab
+#: field:runbot.repo,sticky_protected:0
+msgid "Sticky for Protected Branches"
+msgstr ""
+
+#. module: runbot_gitlab
+#: field:runbot.repo,uses_gitlab:0
+msgid "Use Gitlab"
+msgstr ""
+
+#. module: runbot_gitlab
+#: field:runbot.branch,project_id:0
+msgid "VCS Project"
+msgstr ""
+
+#. module: runbot_gitlab
+#: code:addons/runbot_gitlab/runbot_repo.py:123
+#, python-format
+msgid "id=%d"
+msgstr ""
+
+#. module: runbot_gitlab
+#: code:addons/runbot_gitlab/runbot_repo.py:123
+#, python-format
+msgid "name=%s"
+msgstr ""
+

--- a/runbot_gitlab/runbot_repo_view.xml
+++ b/runbot_gitlab/runbot_repo_view.xml
@@ -7,9 +7,13 @@
       <field name="inherit_id" ref="runbot.view_repo_form"/>
       <field name="arch" type="xml">
 
-        <field name="token" position="before">
-          <field name="uses_gitlab"/>
-        </field>
+        <xpath expr="//group[@string='Params']" position="after">
+          <group string="Gitlab">
+            <field name="uses_gitlab"/>
+            <field attrs="{'invisible': [('uses_gitlab','=',False)]}" name="mr_only"/>
+            <field attrs="{'invisible': [('uses_gitlab','=',False)]}" name="sticky_protected"/>
+          </group>
+        </xpath>
 
         <field name="token" position="attributes">
           <attribute name="string">API Token</attribute>


### PR DESCRIPTION
Standard behavior of module is:
1. To set all protected branches as sticky 
2. To build only merge requests and sticky branches while ignoring normal branches

Users (such as myself) might want a different behavior on this and there should be flexibility allowing this change

As such I made two boolean fields managing the desired behavior and
