### PR TITLE
[REF] runbot_build_instructions: Dual compatibility with odoo 9.0 and 8.0

### DIFF
--- a/runbot_build_instructions/runbot_repo_view.xml
+++ b/runbot_build_instructions/runbot_repo_view.xml
@@ -9,7 +9,7 @@
         <field name="modules" position="attributes">
           <attribute name="attrs">{'required': [('is_custom_build', '=', True)]}</attribute>
         </field>
-        <group string="Params" position="after">
+        <xpath expr="//group" position="after">
           <group name="custom">
             <field name="is_custom_build"/>
             <field name="skip_test_jobs"/>
@@ -19,7 +19,7 @@
             <field name="custom_pre_build_cmd" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="other_repo_id" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
           </group>
-        </group>
+        </xpath>
       </field>
     </record>
 


### PR DESCRIPTION
- Steps to reproduce issue:
  - Download next repositories:
    - odoo/odoo branch 9.0
    - odoo/odoo-extra branch master
    - oca/runbot-addons branch master
  - Apply next patches
    - https://github.com/odoo/odoo-extra/pull/80
    - `find ./odoo-extra/runbot -name res_config_view.xml -exec sed -i 's/base.menu_config/base.menu_administration/g' {} \;`
  - Create database, start server and install `runbot_build_instructions` module.
  - Saw traceback:

``` bash
  File "./odoo/openerp/models.py", line 1267, in _validate_fields
    raise ValidationError('\n'.join(errors))
ParseError: "Invalid view definition

Error details:
View inheritance may not use attribute 'string' as a selector.

Error context:
View `runbot.repo form`
[view_id: 322, xml_id: runbot_build_instructions.view_repo_form, model: runbot.repo, parent_id: 289]
None" while parsing ./runbot-addons/runbot_build_instructions/runbot_repo_view.xml:5, near
<record id="view_repo_form" model="ir.ui.view">
```

This small patch fix this future 9.0 error and is compatible with current version 8.0 too
