### PR TITLE
[ADD] runbot_travis2docker: Add runbot module to work with travis2docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ language: python
 python:
   - "2.7"
 
-sudo: false
-cache: pip
+sudo: required  # Required for docker
+services:
+  - docker
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
 
 addons:
   apt:
@@ -29,11 +34,9 @@ virtualenv:
 install:
   - git clone https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
   - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
-  - pip install gitlab3
   - travis_install_nightly
-  - git clone --depth=1 https://github.com/odoo/odoo-extra ~/odoo-extra
-  # odoo-extra has a bunch of v9 modules which aren't compatible, remove them
-  - (cd ~/odoo-extra; rm -rf $(ls | grep -v runbot$))
+  - pip install -r requirements.txt
+  - if [ "${TESTS}" == "1"  ]; then ${TRAVIS_BUILD_DIR}/.travis_requirements.sh; fi
 
 script:
   - travis_run_tests

--- a/.travis_requirements.sh
+++ b/.travis_requirements.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -v
+# odoo-extra has a bunch of v9 modules which aren't compatible, remove them
+(cd ${HOME}/dependencies/odoo-extra; rm -rf $(ls | grep -v runbot$))
+
+# odoo version 9.0 compatibility
+find ${HOME}/dependencies/odoo-extra/runbot -name res_config_view.xml -exec sed -i 's/base.menu_config/base.menu_administration/g' {} \;
+
+# Disabling matplotlib by https://github.com/travis-ci/travis-ci/issues/4948
+find ${HOME}/dependencies/odoo-extra/runbot -name runbot.py -exec sed -i  '/from matplotlib.font_manager import FontProperties/d' {} \;
+find ${HOME}/dependencies/odoo-extra/runbot -name runbot.py -exec sed -i  '/from matplotlib.textpath import TextToPath/d' {} \;
+find ${HOME}/dependencies/odoo-extra/runbot -name __openerp__.py -exec sed -i  '/'matplotlib'/d' {} \;
+
+# Change cron interval to avoid interference with tests
+find ${HOME}/dependencies/odoo-extra/runbot -name runbot.xml -exec sed -i "s/'interval_number'>1</'interval_number'>60</g" {} \;
+
+
+# Disabling test_crawl (native runbot fail)
+find ${HOME} -name __init__.py -exec sed -i  "/import test_crawl/d" {} \;
+
+# Download docker image required
+if [ "${TESTS}" == "1"  ]; then docker pull vauxoo/odoo-80-image-shippable-auto; fi

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+odoo-extra https://github.com/odoo/odoo-extra master

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+travis2docker

--- a/runbot_travis2docker/README.rst
+++ b/runbot_travis2docker/README.rst
@@ -1,0 +1,82 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+=======================
+Runbot travis to docker
+=======================
+
+This module allows you to generate runbot builds based on docker.
+Use .travis.yml file of your git repository to generate a Dockerfile after that
+start to build a image, run a container to test and re-run the same container with live instance.
+
+Installation
+============
+
+To install this module, you need to:
+
+- Install docker https://docs.docker.com/installationn
+- Install travis2docker
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* Go to menu Runbot/Repository and activate the field check box of "Tavis to docker"
+
+Usage
+=====
+
+To use this module, you need to know the main functionallity of runbot base
+and know the main functionallity of travis and .travis.yml file
+and know the main funcitonallity of oca/maintainer-quality-tools.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/146/9.0
+
+Known issues / Roadmap
+======================
+
+* This module run the just the first build with environment variable TESTS="1"
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/{project_repo}/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+runbot-addons/issues/new?body=module:%20
+runbot_travis2docker%0Aversion:%20
+9.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Moisés López <moylop260@vauxoo.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/runbot_travis2docker/__init__.py
+++ b/runbot_travis2docker/__init__.py
@@ -1,0 +1,7 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models
+from . import tests

--- a/runbot_travis2docker/__openerp__.py
+++ b/runbot_travis2docker/__openerp__.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    "name": "Runbot travis to docker",
+    "summary": "Generate docker with odoo instance based on .travis.yml",
+    "version": "9.0.1.0.0",
+    "category": "runbot",
+    "website": "https://odoo-community.org/",
+    "author": "Vauxoo,Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "depends": [
+        "runbot",
+    ],
+    "external_dependencies": {
+        "python": [
+            'travis2docker',
+        ],
+        'bin': [
+            'docker',
+        ],
+    },
+    "data": [
+        "views/runbot_repo_view.xml",
+    ],
+    "demo": [
+        "demo/runbot_repo_demo.xml",
+    ],
+    "application": False,
+    "installable": True,
+}

--- a/runbot_travis2docker/demo/runbot_repo_demo.xml
+++ b/runbot_travis2docker/demo/runbot_repo_demo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="runbot_repo_demo1" model="runbot.repo">
+            <field name="name">https://github.com/vauxoo-dev/fast-travis-test.git</field>
+            <field name="is_travis2docker_build" eval="True"/>
+        </record>
+
+    </data>
+</openerp>

--- a/runbot_travis2docker/models/__init__.py
+++ b/runbot_travis2docker/models/__init__.py
@@ -1,0 +1,7 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import runbot_build
+from . import runbot_repo

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -1,0 +1,170 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+import os
+import time
+import sys
+
+import openerp
+from openerp import fields, models
+from openerp.addons.runbot_build_instructions.runbot_build \
+    import MAGIC_PID_RUN_NEXT_JOB
+from openerp.addons.runbot.runbot import (
+    grep, rfind, run, _re_error, _re_warning)
+
+from travis2docker.git_run import GitRun
+from travis2docker.travis2docker import main as t2d
+
+_logger = logging.getLogger(__name__)
+
+
+def custom_build(func):
+    # TODO: Make this method more generic for re-use in all custom modules
+    """Decorator for functions which should be overwritten only if
+    is_travis2docker_build is enabled in repo.
+    """
+    def custom_func(self, cr, uid, ids, context=None):
+        args = [
+            ('id', 'in', ids),
+            ('branch_id.repo_id.is_travis2docker_build', '=', True)
+        ]
+        custom_ids = self.search(cr, uid, args, context=context)
+        regular_ids = list(set(ids) - set(custom_ids))
+        ret = None
+        if regular_ids:
+            regular_func = getattr(super(RunbotBuild, self), func.func_name)
+            ret = regular_func(cr, uid, regular_ids, context=context)
+        if custom_ids:
+            assert ret is None
+            ret = func(self, cr, uid, custom_ids, context=context)
+        return ret
+    return custom_func
+
+
+class RunbotBuild(models.Model):
+    _inherit = 'runbot.build'
+
+    dockerfile_path = fields.Char()
+    docker_image = fields.Char()
+    docker_container = fields.Char()
+
+    def get_docker_image(self, cr, uid, build, context=None):
+        git_obj = GitRun(build.repo_id.name, '')
+        image_name = git_obj.owner + '-' + git_obj.repo + ':' + \
+            build.name[:7] + '_' + os.path.basename(build.dockerfile_path)
+        return image_name.lower()
+
+    def get_docker_container(self, cr, uid, build, context=None):
+        return "build_%d" % (build.sequence)
+
+    def job_10_test_base(self, cr, uid, build, lock_path, log_path):
+        'Build docker image'
+        if not build.branch_id.repo_id.is_travis2docker_build:
+            return super(RunbotBuild, self).job_10_test_base(
+                cr, uid, build, lock_path, log_path)
+        if not build.docker_image or not build.dockerfile_path \
+                or build.result == 'skipped':
+            _logger.info('docker build skipping job_10_test_base')
+            return MAGIC_PID_RUN_NEXT_JOB
+        cmd = [
+            'docker', 'build',
+            "--no-cache",
+            "-t", build.docker_image,
+            build.dockerfile_path,
+        ]
+        return self.spawn(cmd, lock_path, log_path)
+
+    def job_20_test_all(self, cr, uid, build, lock_path, log_path):
+        'create docker container'
+        if not build.branch_id.repo_id.is_travis2docker_build:
+            return super(RunbotBuild, self).job_20_test_all(
+                cr, uid, build, lock_path, log_path)
+        if not build.docker_image or not build.dockerfile_path \
+                or build.result == 'skipped':
+            _logger.info('docker build skipping job_20_test_all')
+            return MAGIC_PID_RUN_NEXT_JOB
+        run(['docker', 'rm', '-f', build.docker_container])
+        cmd = [
+            'docker', 'run', '-e', 'INSTANCE_ALIVE=1',
+            '-e', 'RUNBOT=1', '-e', 'UNBUFFER=1',
+            '-p', '%d:%d' % (build.port, 8069),
+            '--name=' + build.docker_container, '-t',
+            build.docker_image,
+        ]
+        return self.spawn(cmd, lock_path, log_path)
+
+    def job_30_run(self, cr, uid, build, lock_path, log_path):
+        'Run docker container with odoo server started'
+        if not build.branch_id.repo_id.is_travis2docker_build:
+            return super(RunbotBuild, self).job_30_run(
+                cr, uid, build, lock_path, log_path)
+        if not build.docker_image or not build.dockerfile_path \
+                or build.result == 'skipped':
+            _logger.info('docker build skipping job_30_run')
+            return MAGIC_PID_RUN_NEXT_JOB
+
+        # Start copy and paste from original method (fix flake8)
+        log_all = build.path('logs', 'job_20_test_all.txt')
+        log_time = time.localtime(os.path.getmtime(log_all))
+        v = {
+            'job_end': time.strftime(
+                openerp.tools.DEFAULT_SERVER_DATETIME_FORMAT, log_time),
+        }
+        if grep(log_all, ".modules.loading: Modules loaded."):
+            if rfind(log_all, _re_error):
+                v['result'] = "ko"
+            elif rfind(log_all, _re_warning):
+                v['result'] = "warn"
+            elif not grep(
+                build.server("test/common.py"), "post_install") or grep(
+                    log_all, "Initiating shutdown."):
+                v['result'] = "ok"
+        else:
+            v['result'] = "ko"
+        build.write(v)
+        build.github_status()
+        # end copy and paste from original method
+
+        cmd = ['docker', 'start', '-i', build.docker_container]
+        return self.spawn(cmd, lock_path, log_path)
+
+    @custom_build
+    def checkout(self, cr, uid, ids, context=None):
+        """Save travis2docker output"""
+        to_be_skipped_ids = ids
+        for build in self.browse(cr, uid, ids, context=context):
+            branch_short_name = build.branch_id.name.replace(
+                'refs/heads/', '', 1).replace('refs/pull/', 'pull/', 1)
+            t2d_path = os.path.join(build.repo_id.root(), 'travis2docker')
+            sys.argv = [
+                'travisfile2dockerfile', build.repo_id.name,
+                branch_short_name, '--root-path=' + t2d_path]
+            try:
+                path_scripts = t2d()
+            except BaseException:  # TODO: Add custom exception to t2d
+                path_scripts = []
+            for path_script in path_scripts:
+                df_content = open(os.path.join(
+                    path_script, 'Dockerfile')).read()
+                if 'ENV TESTS=1' in df_content:
+                    build.dockerfile_path = path_script
+                    build.docker_image = self.get_docker_image(cr, uid, build)
+                    build.docker_container = self.get_docker_container(
+                        cr, uid, build)
+                    if build.id in to_be_skipped_ids:
+                        to_be_skipped_ids.remove(build.id)
+                    break
+        if to_be_skipped_ids:
+            _logger.info('Dockerfile without TESTS=1 env. '
+                         'Skipping builds %s', to_be_skipped_ids)
+            self.skip(cr, uid, to_be_skipped_ids, context=context)
+
+    @custom_build
+    def cleanup(self, cr, uid, ids, context=None):
+        for build in self.browse(cr, uid, ids, context=context):
+            if build.docker_container:
+                run(['docker', 'rm', '-f', build.docker_container])
+                run(['docker', 'rmi', '-f', build.docker_image])

--- a/runbot_travis2docker/models/runbot_repo.py
+++ b/runbot_travis2docker/models/runbot_repo.py
@@ -1,0 +1,12 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import fields, models
+
+
+class RunbotRepo(models.Model):
+    _inherit = "runbot.repo"
+
+    is_travis2docker_build = fields.Boolean('Travis to docker build')

--- a/runbot_travis2docker/tests/__init__.py
+++ b/runbot_travis2docker/tests/__init__.py
@@ -1,0 +1,6 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_runbot_build

--- a/runbot_travis2docker/tests/test_runbot_build.py
+++ b/runbot_travis2docker/tests/test_runbot_build.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+import logging
+import os
+import time
+import xmlrpclib
+
+from openerp.tests.common import TransactionCase
+
+from openerp.tools.misc import mute_logger
+
+_logger = logging.getLogger(__name__)
+
+
+class TestRunbotJobs(TransactionCase):
+
+    def setUp(self):
+        super(TestRunbotJobs, self).setUp()
+        self.build_obj = self.env['runbot.build']
+        self.repo_obj = self.env['runbot.repo']
+        self.branch_obj = self.env['runbot.branch']
+        self.repo = self.repo_obj.search([
+            ('is_travis2docker_build', '=', True)], limit=1)
+        self.repo_domain = [('repo_id', '=', self.repo.id)]
+        self.cron = self.env.ref('runbot.repo_cron')
+        self.cron.write({'active': False})
+        self.build = None
+
+    def tearDown(self):
+        super(TestRunbotJobs, self).tearDown()
+        self.cron.write({'active': True})
+        _logger.info('job_10_test_base log' +
+                     open(os.path.join(self.build.path(), "logs",
+                                       "job_10_test_base.txt")).read())
+        _logger.info('job_20_test_all log' +
+                     open(os.path.join(self.build.path(), "logs",
+                                       "job_20_test_all.txt")).read())
+
+    @mute_logger('openerp.addons.runbot.runbot')
+    def wait_change_job(self, current_job, build,
+                        loops=36, timeout=10):
+        for loop in range(loops):
+            _logger.info("Repo Cron to wait change of state")
+            self.repo.cron()
+            if build.job != current_job:
+                break
+            time.sleep(timeout)
+        return build.job
+
+    def test_jobs(self):
+        'Create build and run all jobs'
+        self.assertEqual(len(self.repo), 1, "Repo not found")
+        _logger.info("Repo update to get branches")
+        self.repo.update()
+        branch = self.branch_obj.search(self.repo_domain + [
+            ('name', 'like', 'fast-travis-oca')], limit=1)
+        self.assertEqual(len(branch), 1, "Branch not found")
+        self.build_obj.search([('branch_id', '=', branch.id)]).unlink()
+
+        _logger.info("Repo update to create builds")
+        self.repo.update()
+        self.build = self.build_obj.search([
+            ('branch_id', '=', branch.id)], limit=1)
+        self.assertEqual(len(self.build) == 0, False, "Build not found")
+        self.assertEqual(
+            self.build.state, u'pending', "State should be pending")
+
+        _logger.info("Repo Cron to change state to pending -> testing")
+        self.repo.cron()
+        self.assertEqual(
+            self.build.state, u'testing', "State should be testing")
+        self.assertEqual(
+            self.build.job, u'job_10_test_base',
+            "Job should be job_10_test_base")
+        new_current_job = self.wait_change_job(self.build.job, self.build)
+
+        self.assertEqual(
+            new_current_job, u'job_20_test_all',
+            "Job should be job_20_test_all")
+        new_current_job = self.wait_change_job(new_current_job, self.build)
+
+        self.assertEqual(
+            new_current_job, u'job_30_run',
+            "Job should be job_30_run")
+        self.assertEqual(
+            self.build.state, u'running',
+            "Job state should be running")
+
+        _logger.info("Wait before of read job_30_run log")
+        time.sleep(360)
+        _logger.info(open(
+            os.path.join(self.build.path(), "logs",
+                         "job_30_run.txt")).read())
+
+        _logger.info("Build running")
+        self.assertEqual(
+            self.build.state, u'running',
+            "Job state should be running still")
+
+        _logger.info("Testing connection")
+        user_ids = self.connection_test(self.build)
+        self.assertEqual(
+            len(user_ids) >= 1, True, "Failed connection test")
+
+        self.build.kill()
+        self.assertEqual(
+            self.build.state, u'done', "Job state should be done")
+
+        self.assertEqual(
+            self.build.result, u'ok', "Job result should be ok")
+
+    def connection_test(self, build):
+        username = "admin"
+        password = "admin"
+        database_name = "openerp_test"
+        port = build.port
+        host = '127.0.0.1'
+        sock_common = xmlrpclib.ServerProxy(
+            "http://%s:%d/xmlrpc/common" % (host, port))
+        uid = sock_common.login(
+            database_name, username, password)
+        sock = xmlrpclib.ServerProxy(
+            "http://%s:%d/xmlrpc/object" % (host, port))
+        user_ids = sock.execute(
+            database_name, uid, password, 'res.users',
+            'search', [('login', '=', 'admin')])
+        return user_ids

--- a/runbot_travis2docker/views/runbot_repo_view.xml
+++ b/runbot_travis2docker/views/runbot_repo_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+  <data>
+
+    <record id="view_runbot_repo_form" model="ir.ui.view">
+      <field name="model">runbot.repo</field>
+      <field name="inherit_id" ref="runbot.view_repo_form"/>
+      <field name="arch" type="xml">
+        <xpath expr="//group" position="after">
+          <group name="travis2docker">
+            <field name="is_travis2docker_build"/>
+          </group>
+        </xpath>
+      </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
- Enable feature to work with docker in runbot using the pypi library travis2docker.
- Reuse MQT scripts to work with runbot.
  - runbot job 10: `travis2docker` and `docker build` to build image
  - runbot job 20: `docker run` to create openerp_test
  - runbot job 30: `docker start` to run instance
- Module tested fully
- This feature avoid create work repetitive to administration of runbot (install new apt packages, install new pip packages) Avoid: "hey!! install this package please. Hey!! add follow new project as depends..."
- This feature avoid developer more than 2 times the same goal (All centralized in MQT scripts)
- This feature add the possibility of create a debugging directly in a build of runbot with a isolated environment.
- This feature could add a possibility of create a new feature to connect by ssh to builds of runbot in a future.
- This PR depends of https://github.com/OCA/maintainer-quality-tools/pull/297 and https://github.com/OCA/maintainer-quality-tools/pull/303
- You can see this module working in production in: http://runbot.vauxoo.com

Result running travis2docker of this PR locally to self-test:
<img width="1032" alt="captura de pantalla 2015-11-22 a las 2 09 02 p m" src="https://cloud.githubusercontent.com/assets/6644187/11325717/b7810ee6-9122-11e5-9938-f2d0fe74dcda.png">
