### PR TITLE
[FIX] runbot_travis2docker: Fix support multi ENV one-line

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -149,7 +149,7 @@ class RunbotBuild(models.Model):
             for path_script in path_scripts:
                 df_content = open(os.path.join(
                     path_script, 'Dockerfile')).read()
-                if 'ENV TESTS=1' in df_content:
+                if ' TESTS=1' in df_content:
                     build.dockerfile_path = path_script
                     build.docker_image = self.get_docker_image(cr, uid, build)
                     build.docker_container = self.get_docker_container(


### PR DESCRIPTION
- Add support when a `.travis.yml` has a `env` with multiple environment variable assigned.
