### PR TITLE
[IMP] runbot_build_instructions: allow the definition of a custom_odoo_path

### DIFF
--- a/runbot_build_instructions/README.rst
+++ b/runbot_build_instructions/README.rst
@@ -18,6 +18,8 @@ checked:
   cloned in the build directory.
 * Custom server path is required to be specified. This is tells runbot which
   executable script to run.
+* Custom Odoo path can be specified. This is where the Odoo folder can be
+  found in the repository.
 * Custom server flags can be specified to add to execution. E.g. --workers=0
 * Pre-build commands can be run such as additional fetch scripts or buildout.
 * An alternate repository can be specified, and then passed on to the custom

--- a/runbot_build_instructions/runbot_build.py
+++ b/runbot_build_instructions/runbot_build.py
@@ -26,6 +26,7 @@ import sys
 import shutil
 
 import openerp
+from openerp import api
 from openerp.osv import orm, fields
 from openerp.addons.runbot.runbot import mkdirs
 
@@ -169,3 +170,13 @@ class runbot_build(orm.Model):
             "--workers=0",
         ] + params
         return cmd, mods
+
+    @api.cr_uid_ids_context
+    def server(self, cr, uid, ids, *l, **kw):
+        for build in self.browse(cr, uid, ids, context=None):
+            if build.repo_id.is_custom_build:
+                custom_odoo_path = build.repo_id.custom_odoo_path
+                if custom_odoo_path and\
+                        os.path.exists(build.path(custom_odoo_path)):
+                    return build.path(custom_odoo_path, *l)
+        return super(runbot_build, self).server(cr, uid, ids, *l, **kw)

--- a/runbot_build_instructions/runbot_repo.py
+++ b/runbot_build_instructions/runbot_repo.py
@@ -53,6 +53,10 @@ class RunbotRepo(models.Model):
         'Custom Pre-build Command',
         help=ARGUMENTS_HELP,
     )
+    custom_odoo_path = fields.Char(
+        'Custom Odoo Path',
+        help="Relative path to Odoo",
+    )
     other_repo_id = fields.Many2one(
         'runbot.repo',
         'Other repository',

--- a/runbot_build_instructions/runbot_repo.py
+++ b/runbot_build_instructions/runbot_repo.py
@@ -55,7 +55,10 @@ class RunbotRepo(models.Model):
     )
     custom_odoo_path = fields.Char(
         'Custom Odoo Path',
-        help="Relative path to Odoo",
+        help="Relative path to Odoo. E.g. put in 'my/odoo' if the relative"
+             " path to the 'base' module in the repository is"
+             " my/odoo/openerp/addons/base. If the option is not set, it"
+             " will assume the default 'odoo'.",
     )
     other_repo_id = fields.Many2one(
         'runbot.repo',

--- a/runbot_build_instructions/runbot_repo_view.xml
+++ b/runbot_build_instructions/runbot_repo_view.xml
@@ -15,6 +15,7 @@
             <field name="skip_test_jobs"/>
             <field name="custom_build_dir" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="custom_server_path" attrs="{'invisible': [('is_custom_build', '=', False)], 'required': [('is_custom_build', '=', True)]}"/>
+            <field name="custom_odoo_path" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="custom_server_params" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="custom_pre_build_cmd" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="other_repo_id" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>

--- a/runbot_build_instructions/runbot_repo_view.xml
+++ b/runbot_build_instructions/runbot_repo_view.xml
@@ -15,7 +15,7 @@
             <field name="skip_test_jobs"/>
             <field name="custom_build_dir" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="custom_server_path" attrs="{'invisible': [('is_custom_build', '=', False)], 'required': [('is_custom_build', '=', True)]}"/>
-            <field name="custom_odoo_path" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
+            <field name="custom_odoo_path" attrs="{'invisible': [('is_custom_build', '=', False)]}" placeholder="odoo"/>
             <field name="custom_server_params" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="custom_pre_build_cmd" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>
             <field name="other_repo_id" attrs="{'invisible': [('is_custom_build', '=', False)]}"/>


### PR DESCRIPTION
The `server` method of `runbot.build` assumes that Odoo is available in the repository root. This pull request allows to configure a `custom_odoo_path` instead for the repository. This can be useful for buildout recipes that pull Odoo into some sub-directory like _parts_.
