### PR TITLE
[FIX] runbot_build_instructions: correct name of log file in link

### DIFF
--- a/runbot_build_instructions/runbot_repo_view.xml
+++ b/runbot_build_instructions/runbot_repo_view.xml
@@ -25,7 +25,7 @@
 
     <template id="build_button" inherit_id="runbot.build_button">
       <xpath expr="//ul[@class='dropdown-menu']/li[5]" position="before">
-        <li><a t-attf-href="http://{{bu['host']}}/runbot/static/build/#{bu['real_dest']}/logs/job_00_prebuild.txt">Full build logs <i class="fa fa-file-text-o"/></a></li>
+        <li><a t-attf-href="http://{{bu['host']}}/runbot/static/build/#{bu['real_dest']}/logs/job_00_init.txt">Full build logs <i class="fa fa-file-text-o"/></a></li>
       </xpath>
     </template>
 


### PR DESCRIPTION
The name of the log file is the name of the method, which is `job_00_init`.
