### PR TITLE
[IMP] runbot_gitlab: fix minor issues

### DIFF
--- a/runbot_gitlab/models/runbot_build.py
+++ b/runbot_gitlab/models/runbot_build.py
@@ -30,7 +30,7 @@ class runbot_build(models.Model):
     @api.depends('repo_id.uses_gitlab', 'branch_id', 'name')
     def _compute_dest(self):
         for build in self.filtered('repo_id.uses_gitlab'):
-            nickname = escape_branch_name(build.branch_id.name)[:32]
+            nickname = escape_branch_name(build.branch_id.name)[:32].lower()
             build.dest = "%05d-%s-%s" % (
                 build.id, nickname, build.name[:6]
             )

--- a/runbot_gitlab/models/runbot_build.py
+++ b/runbot_gitlab/models/runbot_build.py
@@ -63,7 +63,7 @@ class runbot_build(models.Model):
                 ),
                 post_data={
                     'state': state,
-                    'ref': this.branch_id.name,
+                    'ref': this.branch_id.branch_name,
                     'name': 'runbot',
                     'target_url': '//%s/runbot/build/%s' % (
                         this.repo_id.domain(),


### PR DESCRIPTION
This pull request addresses two minor issues:
1. It seems that Gitlab expects just the branchname without leading 'refs/...' for the commit status API. With the complete name the link to the build in our Gitlab instance is broken.
2. The nickname should also be converted to lowercase. This is because dbfilter is case-sensitive. If we  don't convert uppercase characters, there is a mismatch between the hostname, which is treated case-insensitively by the browser, and the database name.
