### PR TITLE
[REF] runbot_travis2docker: Long term test

### DIFF
--- a/runbot_travis2docker/tests/test_runbot_build.py
+++ b/runbot_travis2docker/tests/test_runbot_build.py
@@ -65,14 +65,12 @@ class TestRunbotJobs(TransactionCase):
             })
         self.assertEqual(len(branch), 1, "Branch not found")
         self.build_obj.search([('branch_id', '=', branch.id)]).unlink()
-
-        _logger.info("Repo update to create builds")
-        self.repo.update()
-        self.build = self.build_obj.search([
-            ('branch_id', '=', branch.id)], limit=1)
-        if not self.build:
-            self.build = self.build_obj.create({
-                'branch_id': branch.id, 'name': 'HEAD'})
+        self.build_obj.create({'branch_id': branch.id, 'name': 'HEAD'})
+        # runbot module has a inherit in create method
+        # but a "return id" is missed. Then we need to search it.
+        # https://github.com/odoo/odoo-extra/blob/038fd3e/runbot/runbot.py#L599
+        self.build = self.build_obj.search([('branch_id', '=', branch.id)],
+                                           limit=1)
         self.assertEqual(len(self.build) == 0, False, "Build not found")
 
         if self.build.state == 'done' and self.build.result == 'skipped':


### PR DESCRIPTION
[runbot skip to create builds for old branches](https://github.com/odoo/odoo-extra/blob/038fd3ecf02fa6f63c308cfc723ff26e548d7041/runbot/runbot.py#L326-L328) then we need to force create it if we don't have changes in demo repo
