### PR TITLE
[ADD] runbot_travis2docker: Add log-db option

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -95,7 +95,7 @@ class RunbotBuild(models.Model):
         ] if 'refs/pull/' in build.branch_id.name else [
             '-e', 'TRAVIS_PULL_REQUEST=false',
         ]
-        travis_branch =  build._get_closest_branch_name(
+        travis_branch = build._get_closest_branch_name(
             build.repo_id.id
         )[1].split('/')[-1]
         cmd = [

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -10,6 +10,7 @@ import sys
 
 import openerp
 from openerp import fields, models
+from openerp.tools import config
 from openerp.addons.runbot_build_instructions.runbot_build \
     import MAGIC_PID_RUN_NEXT_JOB
 from openerp.addons.runbot.runbot import (
@@ -108,6 +109,11 @@ class RunbotBuild(models.Model):
             '--name=' + build.docker_container,
             '-t', build.docker_image,
         ] + pr_cmd_env
+        logdb = cr.dbname
+        if config['db_host'] and grep(build.server('sql_db.py'), 'allow_uri'):
+            logdb = 'postgres://{cfg[db_user]}:{cfg[db_password]}@' +\
+                    '{cfg[db_host]}/{db}'.format(cfg=config, db=cr.dbname)
+        cmd += ['-e', 'SERVER_OPTIONS="--log-db=%s"' % logdb]
         return self.spawn(cmd, lock_path, log_path)
 
     def job_30_run(self, cr, uid, build, lock_path, log_path):

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -110,7 +110,7 @@ class RunbotBuild(models.Model):
             '-t', build.docker_image,
         ] + pr_cmd_env
         logdb = cr.dbname
-        if config['db_host'] and grep(build.server('sql_db.py'), 'allow_uri'):
+        if config['db_host']:
             logdb = 'postgres://{cfg[db_user]}:{cfg[db_password]}@' +\
                     '{cfg[db_host]}/{db}'.format(cfg=config, db=cr.dbname)
         cmd += ['-e', 'SERVER_OPTIONS="--log-db=%s"' % logdb]


### PR DESCRIPTION
- Add env var to log to parent database

Depends:
- [ ] OCA/maintainer-quality-tools#358

Disclaimer - this is theoretical and has not been functionally tested yet
