### PR TITLE
[ADD] allow to configure extra parameters for pylint

### DIFF
--- a/runbot_pylint/models/runbot_build.py
+++ b/runbot_pylint/models/runbot_build.py
@@ -168,8 +168,9 @@ class RunbotBuild(models.Model):
                                   "$PYTHONPATH:%s\n" %
                                   (build.server()))
             for module_to_check_pylint in modules_to_check_pylint:
-                cmd = "pylint --rcfile=%s %s" % \
+                cmd = "pylint --rcfile=%s %s %s" % \
                       (path_pylint_conf,
+                       build.repo_id.pylint_extra_parameters or '',
                        os.path.join(build.server('addons'),
                                     module_to_check_pylint))
                 f_pylint_run_sh.write(cmd + '\n')

--- a/runbot_pylint/models/runbot_repo.py
+++ b/runbot_pylint/models/runbot_repo.py
@@ -30,6 +30,8 @@ class RunbotRepo(models.Model):
 
     pylint_conf_path = fields.Char(
         help='Relative path to pylint conf file')
+    pylint_extra_parameters = fields.Char(
+        help='Pass extra parameters to pylint')
     check_pylint = fields.Boolean(
         help='Check pylint to modules of this repo')
 

--- a/runbot_pylint/views/runbot_pylint_view.xml
+++ b/runbot_pylint/views/runbot_pylint_view.xml
@@ -9,6 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='token']" position="after">
                     <field name="pylint_conf_path"/>
+                    <field name="pylint_extra_parameters"/>
                     <field name="check_pylint"/>
                 </xpath>
             </field>


### PR DESCRIPTION
this way, we can be a lot more flexible. In my case, I need to load the pylint-odoo plugin, but this allows for whatever else can't be set in the config file