### PR TITLE
[FIX] runbot_travis2docker: Fix compatibility for url without https prefix

### DIFF
--- a/runbot_travis2docker/demo/runbot_repo_demo.xml
+++ b/runbot_travis2docker/demo/runbot_repo_demo.xml
@@ -3,7 +3,7 @@
     <data>
 
         <record id="runbot_repo_demo1" model="runbot.repo">
-            <field name="name">https://github.com/vauxoo-dev/fast-travis-test.git</field>
+            <field name="name">github.com/vauxoo-dev/fast-travis-test.git</field>
             <field name="is_travis2docker_build" eval="True"/>
         </record>
 

--- a/runbot_travis2docker/demo/runbot_repo_demo.xml
+++ b/runbot_travis2docker/demo/runbot_repo_demo.xml
@@ -3,7 +3,7 @@
     <data>
 
         <record id="runbot_repo_demo1" model="runbot.repo">
-            <field name="name">github.com/vauxoo-dev/fast-travis-test.git</field>
+            <field name="name">https://github.com/vauxoo-dev/fast-travis-test.git</field>
             <field name="is_travis2docker_build" eval="True"/>
         </record>
 

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -169,8 +169,12 @@ class RunbotBuild(models.Model):
             branch_short_name = build.branch_id.name.replace(
                 'refs/heads/', '', 1).replace('refs/pull/', 'pull/', 1)
             t2d_path = os.path.join(build.repo_id.root(), 'travis2docker')
+            repo_name = build.repo_id.name
+            if not (repo_name.startswith('https://') or
+                    repo_name.startswith('git@')):
+                repo_name = 'https://' + repo_name
             sys.argv = [
-                'travisfile2dockerfile', build.repo_id.name,
+                'travisfile2dockerfile', repo_name,
                 branch_short_name, '--root-path=' + t2d_path,
             ]
             try:


### PR DESCRIPTION
We have the following patch: https://github.com/gurneyalex/odoo-extra/commit/92b578a4a3bfca8f23dc474357938be7f43fccd6
But runbot_travis2docker is not working with this one

Fix https://github.com/OCA/runbot-addons/issues/105