### PR TITLE
[FIX] runbot_travis2docker: Fix server options

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -121,8 +121,10 @@ class RunbotBuild(models.Model):
         ] + pr_cmd_env
         logdb = cr.dbname
         if config['db_host'] and not travis_branch.startswith('7.0'):
-            logdb = 'postgres://{cfg[db_user]}:{cfg[db_password]}@' +\
-                    '{cfg[db_host]}/{db}'.format(cfg=config, db=cr.dbname)
+            logdb = 'postgres://%s:%s@%s/%s' % (
+                config['db_user'], config['db_password'],
+                config['db_host'], cr.dbname,
+            )
         cmd += ['-e', 'SERVER_OPTIONS="--log-db=%s"' % logdb]
         return self.spawn(cmd, lock_path, log_path)
 


### PR DESCRIPTION
* Fix interpolation on server options due to multi line

This should fix log issue reported in #105. Multiline string & `.format` weren't playing nicely, resulting in the following in SERVER_OPTIONS:
```
"--log-db=postgres://{cfg[db_user]}:{cfg[db_password]}@localhost/runbot"
```