### PR TITLE
[REF] runbot_travis2docker: Auto pull image for long-term updates

### DIFF
--- a/.travis_requirements.sh
+++ b/.travis_requirements.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
 
 set -v
+
+export DEPS=${HOME}/dependencies
 # odoo-extra has a bunch of v9 modules which aren't compatible, remove them
-(cd ${HOME}/dependencies/odoo-extra; rm -rf $(ls | grep -v runbot$))
+(cd $DEPS/odoo-extra; rm -rf $(ls | grep -v runbot$))
 
 # odoo version 9.0 compatibility
-find ${HOME}/dependencies/odoo-extra/runbot -name res_config_view.xml -exec sed -i 's/base.menu_config/base.menu_administration/g' {} \;
+sed -i 's/base.menu_config/base.menu_administration/g' ${DEPS}/odoo-extra/runbot/res_config_view.xml
 
 # Disabling matplotlib by https://github.com/travis-ci/travis-ci/issues/4948
-find ${HOME}/dependencies/odoo-extra/runbot -name runbot.py -exec sed -i  '/from matplotlib.font_manager import FontProperties/d' {} \;
-find ${HOME}/dependencies/odoo-extra/runbot -name runbot.py -exec sed -i  '/from matplotlib.textpath import TextToPath/d' {} \;
-find ${HOME}/dependencies/odoo-extra/runbot -name __openerp__.py -exec sed -i  '/'matplotlib'/d' {} \;
+sed -i '/from matplotlib.font_manager import FontProperties/d' $DEPS/odoo-extra/runbot/runbot.py
+sed -i '/from matplotlib.textpath import TextToPath/d' $DEPS/odoo-extra/runbot/runbot.py
+sed -i  '/'matplotlib'/d' $DEPS/odoo-extra/runbot/__openerp__.py
 
 # Change cron interval to avoid interference with tests
-find ${HOME}/dependencies/odoo-extra/runbot -name runbot.xml -exec sed -i "s/'interval_number'>1</'interval_number'>60</g" {} \;
-
+sed -i "s/'interval_number'>1</'interval_number'>60</g" $DEPS/odoo-extra/runbot/runbot.xml
 
 # Disabling test_crawl (native runbot fail)
 find ${HOME} -name __init__.py -exec sed -i  "/import test_crawl/d" {} \;
-
-# Download docker image required
-if [[ "${TESTS}" == "1"  ]]; then docker pull vauxoo/odoo-80-image-shippable-auto; fi

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -78,7 +78,7 @@ class RunbotBuild(models.Model):
             return MAGIC_PID_RUN_NEXT_JOB
         cmd = [
             'docker', 'build',
-            "--no-cache",
+            "--no-cache", '--pull',
             "-t", build.docker_image,
             build.dockerfile_path,
         ]


### PR DESCRIPTION
 - Auto pull image allow us avoid a sys-admin request to run the command:
   - `docker pull IMAGE`
   - Because the parameter `docker build --pull... ` have the following description: `--pull  Always attempt to pull a newer version of the image`


 - Delete manual pull of image and clean script