### PR TITLE
[IMP] runbot_travis2docker: Security and ssh features

### DIFF
--- a/runbot_travis2docker/__openerp__.py
+++ b/runbot_travis2docker/__openerp__.py
@@ -6,7 +6,7 @@
 {
     "name": "Runbot travis to docker",
     "summary": "Generate docker with odoo instance based on .travis.yml",
-    "version": "9.0.1.1.0",
+    "version": "9.0.1.2.0",
     "category": "runbot",
     "website": "https://odoo-community.org/",
     "author": "Vauxoo,Odoo Community Association (OCA)",

--- a/runbot_travis2docker/migrations/9.0.1.2.0/post-migrate.py
+++ b/runbot_travis2docker/migrations/9.0.1.2.0/post-migrate.py
@@ -1,0 +1,10 @@
+# coding: utf-8
+# © 2017 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+    """Skip new feature for old runbot builds."""
+    cr.execute("UPDATE runbot_build SET docker_executed_commands = true")
+    cr.commit()

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -3,6 +3,9 @@
 #   Coded by: moylop260@vauxoo.com
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+# Allow old api because is based original methods are old api from odoo
+# pylint: disable=old-api7-method-defined
+
 import logging
 import os
 import requests
@@ -184,6 +187,7 @@ class RunbotBuild(models.Model):
             sys.argv = [
                 'travisfile2dockerfile', repo_name,
                 branch_short_name, '--root-path=' + t2d_path,
+                '--exclude-after-success',
             ]
             try:
                 path_scripts = t2d()

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -63,7 +63,7 @@ class RunbotBuild(models.Model):
     docker_container = fields.Char()
     docker_executed_commands = fields.Boolean(
         help='True: Executed "docker exec CONTAINER_BUILD custom_commands"',
-        readonly=True)
+        readonly=True, copy=False)
 
     def get_docker_image(self, cr, uid, build, context=None):
         git_obj = GitRun(build.repo_id.name, '')

--- a/runbot_travis2docker/tests/test_runbot_build.py
+++ b/runbot_travis2docker/tests/test_runbot_build.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+import subprocess
 import time
 import xmlrpclib
 
@@ -108,6 +109,15 @@ class TestRunbotJobs(TransactionCase):
             "Job state should be running still")
         self.assertEqual(
             len(user_ids) >= 1, True, "Failed connection test")
+
+        self.repo.cron()
+        self.assertTrue(self.build.docker_executed_commands,
+                        "docker_executed_commands should be True")
+        time.sleep(5)
+        output = subprocess.check_output([
+            "docker", "exec", self.build.docker_container,
+            "/etc/init.d/ssh", "status"])
+        self.assertIn('sshd is running', output, "SSH should be running")
 
         self.build.kill()
         self.assertEqual(


### PR DESCRIPTION
- Use a non-sudoer user
  - Updating travis2docker use `odoo` user by default
- Start ssh service with `root`
- Add ssh keys for github committer and author

NOTE: This change requires a upgrade of travis2docker `pip install -U travis2docker`

For merger: Use github button `Merge and squash`