### PR TITLE
[REF] runbot_travis2docker: Faster

### DIFF
--- a/runbot_travis2docker/models/__init__.py
+++ b/runbot_travis2docker/models/__init__.py
@@ -5,3 +5,4 @@
 
 from . import runbot_build
 from . import runbot_repo
+from . import runbot_branch

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -1,0 +1,27 @@
+# coding: utf-8
+# © 2015 Vauxoo
+#   Coded by: moylop260@vauxoo.com
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+# Allow old api because is based original methods are old api from odoo
+# pylint: disable=old-api7-method-defined
+
+from openerp import models
+
+
+class RunbotBranch(models.Model):
+    _inherit = "runbot.branch"
+
+    def _get_branch_quickconnect_url(self, cr, uid, ids, fqdn, dest,
+                                     context=None):
+        """Remove debug=1 because is too slow
+        Remove database default name because is used openerp_test from MQT
+        """
+        res = super(RunbotBranch, self)._get_branch_quickconnect_url(
+            cr, uid, ids, fqdn, dest, context=context)
+        for branch in self.browse(cr, uid, ids, context=context):
+            if branch.repo_id.is_travis2docker_build:
+                dbname = "db=%s-all&" % dest
+                res[branch.id] = res[branch.id].replace(dbname, "").replace(
+                    "?debug=1", "")
+        return res


### PR DESCRIPTION
- [x] Fix https://github.com/OCA/runbot-addons/issues/122
  - [x] Open url after finish build in order to simulate the-first-user to generate routing map and static files
- [x] Remove `debug=1` because is too slow and is not used for all cases.
- [x] Remove database default name based on `build.dest` field because now is used just one database `openerp_test` (default name from MQT)

Note: It requires update [runbot master branch](https://github.com/odoo/odoo-extra/tree/master/runbot) to get the new original method [runbot._get_branch_quickconnect_url](https://github.com/odoo/odoo-extra/blob/851320c0175ce21082eb39272005a80e028de4c5/runbot/runbot.py#L474)