### PR TITLE
[REF] runbot_travis2docker: Ignore raise for github response and fix docker run

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -227,7 +227,7 @@ class RunbotBuild(models.Model):
 
     def get_ssh_keys(self, cr, uid, build, context=None):
         response = build.repo_id.github(
-            "/repos/:owner/:repo/commits/%s" % build.name)
+            "/repos/:owner/:repo/commits/%s" % build.name, ignore_errors=True)
         if not response:
             return
         keys = ""

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -126,13 +126,13 @@ class RunbotBuild(models.Model):
             '--name=' + build.docker_container,
             '-t',
         ] + pr_cmd_env
-        logdb = cr.dbname
-        if config['db_host'] and not travis_branch.startswith('7.0'):
-            logdb = 'postgres://%s:%s@%s/%s' % (
-                config['db_user'], config['db_password'],
-                config['db_host'], cr.dbname,
-            )
-        cmd += ['-e', 'SERVER_OPTIONS="--log-db=%s"' % logdb]
+        if all([config['db_user'], config['db_password'], config['db_host'],
+                not travis_branch.startswith('7.0')]):
+            config['cr_dbname'] = cr.dbname
+            logdb = ('postgres://'
+                     '%(db_user)s:%(db_password)s@%(db_host)s/%(cr_dbname)s'
+                     ) % config
+            cmd += ['-e', 'SERVER_OPTIONS="--log-db=%s"' % logdb]
         return self.spawn(cmd + [build.docker_image], lock_path, log_path)
 
     def job_21_coverage(self, cr, uid, build, lock_path, log_path):

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -124,7 +124,7 @@ class RunbotBuild(models.Model):
             '-p', '%d:%d' % (build.port, 8069),
             '-p', '%d:%d' % (build.port + 1, 22),
             '--name=' + build.docker_container,
-            '-t', build.docker_image,
+            '-t',
         ] + pr_cmd_env
         logdb = cr.dbname
         if config['db_host'] and not travis_branch.startswith('7.0'):
@@ -133,7 +133,7 @@ class RunbotBuild(models.Model):
                 config['db_host'], cr.dbname,
             )
         cmd += ['-e', 'SERVER_OPTIONS="--log-db=%s"' % logdb]
-        return self.spawn(cmd, lock_path, log_path)
+        return self.spawn(cmd + [build.docker_image], lock_path, log_path)
 
     def job_21_coverage(self, cr, uid, build, lock_path, log_path):
         if (not build.branch_id.repo_id.is_travis2docker_build and


### PR DESCRIPTION
- Ignore a raise if committer user is not found from github
- Fix docker run command to use IMAGE as last parameter
- Fix --db-log parameter: It is used if all parameters are defined