### PR TITLE
[REF] runbot_travis2docker: Ignore raise for github response

### DIFF
--- a/.travis_requirements.sh
+++ b/.travis_requirements.sh
@@ -3,6 +3,9 @@
 set -v
 
 export DEPS=${HOME}/dependencies
+# odoo-extra break compatibility because change name of many methods
+# TODO: Test new changes and remove this freeze sha
+(cd $DEPS/odoo-extra; git reset --hard 0c41e17^)
 # odoo-extra has a bunch of v9 modules which aren't compatible, remove them
 (cd $DEPS/odoo-extra; rm -rf $(ls | grep -v runbot$))
 

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -227,7 +227,7 @@ class RunbotBuild(models.Model):
 
     def get_ssh_keys(self, cr, uid, build, context=None):
         response = build.repo_id.github(
-            "/repos/:owner/:repo/commits/%s" % build.name)
+            "/repos/:owner/:repo/commits/%s" % build.name, ignore_errors=True)
         if not response:
             return
         keys = ""


### PR DESCRIPTION
- Ignore a raise if committer user is not found from github

Fix extracted from https://github.com/OCA/runbot-addons/pull/126