### PR TITLE
[REF] runbot_travis2docker: Adding new enrironment variable WEBLATE_SSH

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -91,7 +91,7 @@ class RunbotBranch(models.Model):
                         continue
                     component = [item for item in project['components']
                                  if item['git_export']]
-                    if len(component) > 1:
+                    if len(component) != 1:
                         continue
                     component = component[0]
                     remote = 'wl-%s-%s' % (project['slug'], component['slug'])

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -68,7 +68,8 @@ class RunbotBranch(models.Model):
     def cron_weblate(self):
         for branch in self.search([('uses_weblate', '=', True)]):
             if (not branch.repo_id.weblate_token or
-                    not branch.repo_id.weblate_url):
+                    not branch.repo_id.weblate_url or
+                    not branch.repo_id.weblate_ssh):
                 continue
             cmd = ['git', '--git-dir=%s' % branch.repo_id.path]
             projects = self.get_weblate_projects(branch.repo_id.weblate_url,
@@ -88,10 +89,15 @@ class RunbotBranch(models.Model):
                          ('uses_weblate', '=', True)])
                     if has_build:
                         continue
-                    remote = 'wl-%s' % project['slug']
+                    component = [item for item in project['components']
+                                 if item['git_export']]
+                    if len(component) > 1:
+                        continue
+                    component = component[0]
+                    remote = 'wl-%s-%s' % (project['slug'], component['slug'])
                     url_repo = '/'.join([
-                        branch.repo_id.weblate_url.replace('api', 'git'),
-                        project['slug'], component['slug']])
+                        branch.repo_id.weblate_ssh, project['slug'],
+                        component['slug']])
                     try:
                         subprocess.check_output(cmd + ['remote', 'add', remote,
                                                        url_repo])

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -119,8 +119,9 @@ class RunbotBuild(models.Model):
                 '-e', ('WEBLATE_TOKEN=%s' %
                        build.branch_id.repo_id.weblate_token),
                 '-e', ('WEBLATE_HOST=%s' %
-                       build.branch_id.repo_id.weblate_url)
-            ])
+                       build.branch_id.repo_id.weblate_url),
+                '-e', ('WEBLATE_SSH=%s' %
+                       build.branch_id.repo_id.weblate_ssh)])
             if build.branch_id.repo_id.weblate_languages:
                 wl_cmd_env.extend([
                     '-e', 'LANG_ALLOWED=%s' %

--- a/runbot_travis2docker/models/runbot_repo.py
+++ b/runbot_travis2docker/models/runbot_repo.py
@@ -16,6 +16,8 @@ class RunbotRepo(models.Model):
     is_travis2docker_build = fields.Boolean('Travis to docker build')
     travis2docker_test_disable = fields.Boolean('Test Disable?')
     weblate_url = fields.Char(default="https://weblate.odoo-community.org/api")
+    weblate_ssh = fields.Char(
+        default="ssh://user@webpage.com")
     weblate_token = fields.Char()
     weblate_languages = fields.Char(help="List of code iso of languages E.g."
                                     " en_US,es_ES")

--- a/runbot_travis2docker/views/runbot_repo_view.xml
+++ b/runbot_travis2docker/views/runbot_repo_view.xml
@@ -15,6 +15,7 @@
             <field name="is_travis2docker_build"/>
             <field name="travis2docker_test_disable" attrs="{'invisible': [('is_travis2docker_build', '=', False)]}"/>
             <field name="weblate_url"/>
+            <field name="weblate_ssh"/>
             <label for="weblate_token"/>
             <div class="o_row">
                 <field name="weblate_token"/>


### PR DESCRIPTION
This variable should be used to made the fetch of the weblate git repository

This change is necessary because weblate does not work well when trying to put security to the internal repository

Previously the weblate gitexport module was used to download the changes from weblate https://docs.weblate.org/en/latest/vcs.html#https-repositories now weblate should be enable ssh access to the vcs folder

Related with https://github.com/Vauxoo/runbot-addons/pull/133