### PR TITLE
[9.0][IMP] runbot_travis2docker: Add custom image

### DIFF
--- a/runbot_travis2docker/README.rst
+++ b/runbot_travis2docker/README.rst
@@ -65,6 +65,7 @@ Contributors
 ------------
 
 * Moisés López <moylop260@vauxoo.com>
+* Dave Lasley <dave@laslabs.com>
 
 Maintainer
 ----------

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -214,6 +214,7 @@ class RunbotBuild(models.Model):
                 'travisfile2dockerfile', repo_name,
                 branch_short_name, '--root-path=' + t2d_path,
                 '--exclude-after-success',
+                '--docker-image=%s' % build.repo_id.travis2docker_image,
             ]
             try:
                 path_scripts = t2d()

--- a/runbot_travis2docker/models/runbot_repo.py
+++ b/runbot_travis2docker/models/runbot_repo.py
@@ -15,10 +15,17 @@ class RunbotRepo(models.Model):
 
     is_travis2docker_build = fields.Boolean('Travis to docker build')
     travis2docker_test_disable = fields.Boolean('Test Disable?')
+    travis2docker_image = fields.Char(
+        default=lambda s: s._default_travis2docker_image(),
+    )
     weblate_url = fields.Char(default="https://weblate.odoo-community.org/api")
     weblate_token = fields.Char()
     weblate_languages = fields.Char(help="List of code iso of languages E.g."
                                     " en_US,es_ES")
+
+    @api.model
+    def _default_travis2docker_image(self):
+        return 'vauxoo/odoo-80-image-shippable-auto'
 
     @api.multi
     @api.constrains('weblate_languages')

--- a/runbot_travis2docker/views/runbot_repo_view.xml
+++ b/runbot_travis2docker/views/runbot_repo_view.xml
@@ -14,6 +14,10 @@
           <group name="travis2docker">
             <field name="is_travis2docker_build"/>
             <field name="travis2docker_test_disable" attrs="{'invisible': [('is_travis2docker_build', '=', False)]}"/>
+            <field name="travis2docker_image"
+                   attrs="{'invisible': [('is_travis2docker_build', '=', False)],
+                           'required': [('is_travis2docker_build', '=', True)]
+                           }"/>
             <field name="weblate_url"/>
             <label for="weblate_token"/>
             <div class="o_row">


### PR DESCRIPTION
* Add ability to define custom image for travis2docker builds
* Default to standard `vauxoo/odoo-80-shippable` to make the image more obvious to user