### PR TITLE
[FIX] runbot_travis2docker: Fix when the components on weblate are more 25

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -56,11 +56,18 @@ class RunbotBranch(models.Model):
                 break
             page += 1
         for project in items:
-            response = session.get('%s/projects/%s/components'
-                                   % (url, project['slug']))
-            response.raise_for_status()
-            data = response.json()
-            project['components'] = data['results']
+            components = []
+            page = 1
+            while True:
+                response = session.get('%s/projects/%s/components/?page=%s'
+                                       % (url, project['slug'], page))
+                response.raise_for_status()
+                data = response.json()
+                components.extend(data['results'] or [])
+                if not data['next']:
+                    break
+                page += 1
+            project['components'] = components
             projects.append(project)
         return projects
 


### PR DESCRIPTION
When the components it is more that 25 the API of Weblate paginated the results, then should be get each page

For more information https://docs.weblate.org/en/latest/api.html#any--

Related with https://github.com/Vauxoo/runbot-addons/pull/140