### PR TITLE
[FIX] runbot_travis2docker: Fix the regular expression to detect the domain containing '-'

### DIFF
--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -43,7 +43,7 @@ class RunbotBranch(models.Model):
         cmd = ['ssh-keyscan', '-p']
         match = re.search(
             r'(ssh\:\/\/\w+@(?P<host>[a-zA-Z0-9_.-]+))(:{0,1})'
-            '(?P<port>(\d+))?', ssh)
+            r'(?P<port>(\d+))?', ssh)
         if not match:
             return False
         data = match.groupdict()

--- a/runbot_travis2docker/models/runbot_branch.py
+++ b/runbot_travis2docker/models/runbot_branch.py
@@ -42,8 +42,8 @@ class RunbotBranch(models.Model):
             'Are you sure you want to continue connecting (yes/no)?'"""
         cmd = ['ssh-keyscan', '-p']
         match = re.search(
-            r'(ssh\:\/\/\w+@(?P<host>[\w\.]+))(:{0,1})(?P<port>(\d+))?',
-            ssh)
+            r'(ssh\:\/\/\w+@(?P<host>[a-zA-Z0-9_.-]+))(:{0,1})'
+            '(?P<port>(\d+))?', ssh)
         if not match:
             return False
         data = match.groupdict()


### PR DESCRIPTION
Change the regular expression to support domain containing '-' equal to `translation.odoo-community.org`

![image](https://user-images.githubusercontent.com/1387970/30603672-3c3c14ac-9d36-11e7-9376-631522e602ef.png)