### PR TITLE
[REF] travis_requirements: Download big image

### DIFF
--- a/.travis_requirements.sh
+++ b/.travis_requirements.sh
@@ -22,3 +22,6 @@ sed -i "s/'interval_number'>1</'interval_number'>60</g" $DEPS/odoo-extra/runbot/
 
 # Disabling test_crawl (native runbot fail)
 find ${HOME} -name __init__.py -exec sed -i  "/import test_crawl/d" {} \;
+
+# Download docker image required
+if [[ "${TESTS}" == "1"  ]]; then docker pull vauxoo/odoo-80-image-shippable-auto; fi


### PR DESCRIPTION
Currently CI is red because a big docker image is download during test running and expire the max time waiting