### PR TITLE
[FIX] travis_requirements: Allow freeze a compatible version of runbot module

### DIFF
--- a/.travis_requirements.sh
+++ b/.travis_requirements.sh
@@ -5,7 +5,7 @@ set -v
 export DEPS=${HOME}/dependencies
 # odoo-extra break compatibility because change name of many methods
 # TODO: Test new changes and remove this freeze sha
-(cd $DEPS/odoo-extra; git reset --hard 0c41e17^)
+(cd $DEPS/odoo-extra; git fetch --unshallow; git reset --hard 0c41e17^)
 # odoo-extra has a bunch of v9 modules which aren't compatible, remove them
 (cd $DEPS/odoo-extra; rm -rf $(ls | grep -v runbot$))
 

--- a/runbot_travis2docker/tests/test_runbot_build.py
+++ b/runbot_travis2docker/tests/test_runbot_build.py
@@ -83,7 +83,7 @@ class TestRunbotJobs(TransactionCase):
 
     @mute_logger('openerp.addons.runbot.runbot')
     def wait_change_job(self, current_job, build,
-                        loops=36, timeout=10):
+                        loops=60, timeout=15):
         for loop in range(loops):
             _logger.info("Repo Cron to wait change of state")
             self.repo.cron()


### PR DESCRIPTION
Fix https://github.com/OCA/runbot-addons/pull/132#issuecomment-357814884

NOTE: Here we can to do so much but now we need a small fix in order to have travis green to merge other PRs