### PR TITLE
[FIX] runbot_travis2docker: Remove db parameter in URLs when t2d is used

### DIFF
--- a/runbot_travis2docker/__manifest__.py
+++ b/runbot_travis2docker/__manifest__.py
@@ -25,6 +25,7 @@
         "views/runbot_build_view.xml",
         "views/runbot_branch_view.xml",
         "data/ir_cron_data.xml",
+        "templates/build.xml",
     ],
     "demo": [
         "demo/runbot_repo_demo.xml",

--- a/runbot_travis2docker/templates/build.xml
+++ b/runbot_travis2docker/templates/build.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="build_button_inherit" inherit_id="runbot.build_button">
+        <!-- This removes the db name parameter from the URL, if it's a t2d build, because the name won't match.
+             We look for the full URL because, if it changes in the future, it should fail.
+        -->
+        <xpath
+            expr="(//a[@t-attf-href=&quot;http://{{bu['domain']}}/?db={{bu['real_dest']}}-all&quot;])[2]"
+            position="attributes">
+            <attribute
+                name="t-attf-href"
+                remove="db={{bu['real_dest']}}-all"
+                add="{{'' if repo.is_travis2docker_build else 'db=%s-all' % bu['real_dest']}}"
+                separator="?"/>
+        </xpath>
+        <xpath
+            expr="(//a[@t-attf-href=&quot;http://{{bu['domain']}}/?db={{bu['real_dest']}}-all&quot;])[1]"
+            position="attributes">
+            <attribute
+                name="t-attf-href"
+                remove="db={{bu['real_dest']}}-all"
+                add="{{'' if repo.is_travis2docker_build else 'db=%s-all' % bu['real_dest']}}"
+                separator="?"/>
+        </xpath>
+
+        <!-- Hides the button if t2d was used, because the db *-base is not produced -->
+        <xpath
+            expr="//a[@t-attf-href=&quot;http://{{bu['domain']}}/?db={{bu['real_dest']}}-base&quot;]/.."
+            position="attributes">
+                <attribute name="t-if" add="repo.is_travis2docker_build" separator=" and "/>
+            </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
When builds are generated using travis2docker, the database name will
always be set to `openerp_test`. Therefore, the db name given by default
by Runbot should not be used in the build' sign in URL.

This change ensures URLs include the db name parameter only when the
build was not generated using travis2docker.

In addition, this hides the "Connect base" button when the build was not
generated using travis2docker, because the database *-base is not
created in such cases.