### PR TITLE
[ADD] map runbot's `warn` result to gitlab's `success_with_warnings`

### DIFF
--- a/runbot_gitlab/models/runbot_build.py
+++ b/runbot_gitlab/models/runbot_build.py
@@ -49,6 +49,8 @@ class RunbotBuild(models.Model):
                     state = 'failed'
                     if build.result == 'ok':
                         state = 'success'
+                    if build.result == 'warn':
+                        state = 'success_with_warnings'
                     if build.result == 'ko':
                         state = 'failed'
                     if build.result == 'skipped':


### PR DESCRIPTION
@moylop260 so this was my naive approach to implement the warnings. Didn't work, and I was convinced to do something stupid, until I looked this up at the gitlab side:
https://gitlab.com/gitlab-org/gitlab-ce/blob/master/lib/api/commit_statuses.rb#L98

So next step is to check if it's just as simple as adding the warning status there, but my ruby is not really existing. Any pointers are appreciated.