### PR TITLE
[FIX] runbot_travis2docker: Skip method if there are not builds

### DIFF
--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -167,11 +167,11 @@ class RunbotBuild(models.Model):
 
     def _local_cleanup(self):
         builds = self.filtered('branch_id.repo_id.is_travis2docker_build')
-        super(RunbotBuild, self - builds)._local_cleanup()
-        for build in builds:
-            if build.docker_container:
-                subprocess.call(['docker', 'rm', '-f', build.docker_container])
-                subprocess.call(['docker', 'rmi', '-f', build.docker_image])
+        if self - builds:
+            super(RunbotBuild, self - builds)._local_cleanup()
+        for build in builds.filtered('docker_container'):
+            subprocess.call(['docker', 'rm', '-vf', build.docker_container])
+            subprocess.call(['docker', 'rmi', '-f', build.docker_image])
 
     def _get_ssh_keys(self):
         self.ensure_one()


### PR DESCRIPTION
Cleanup original method process cleaning even if you don't have builds.
https://github.com/odoo/runbot/blob/e815571d14163c8af6c19637c244ff022abaa883/runbot/models/build.py#L330-L363

Then we need to skip the original method if there are not builds.

Note: The original method run a query without postgresql port, if you
have changed it then will raise an error.

Uses -v in order to remove the volumes of the container