### PR TITLE
[FIX] runbot_gitlab: http://github.com/odoo/runbot/pull/33 compatibility

### DIFF
--- a/runbot_gitlab/models/runbot_repo.py
+++ b/runbot_gitlab/models/runbot_repo.py
@@ -56,8 +56,8 @@ class RunbotRepo(models.Model):
         repos_gitlab = self.filtered('uses_gitlab')
         for repo_gitlab in repos_gitlab:
             cmd_gitlab = cmd.copy()
-            if cmd_gitlab == ['fetch', '-p', 'origin',
-                              '+refs/pull/*/head:refs/pull/*']:
+            if ('fetch' in cmd_gitlab
+                    and cmd_gitlab[-1] == '+refs/pull/*/head:refs/pull/*'):
                 cmd_gitlab.pop()
                 cmd_gitlab.append('+refs/merge-requests/*/head:refs/pull/*')
             return super(RunbotRepo, repos_gitlab)._git(cmd_gitlab)


### PR DESCRIPTION
This fix restores the compatiblity of runbot gitlab if
http://github.com/odoo/runbot/pull/33 gets merged