### PR TITLE
[FIX] runbot_gitlab: Retrieve correctly SSH keys when under GitLab CI

### DIFF
--- a/runbot_gitlab/models/runbot_repo.py
+++ b/runbot_gitlab/models/runbot_repo.py
@@ -74,7 +74,7 @@ class RunbotRepo(models.Model):
             input: URL_GITLAB/User.keys... instead of
                    URL_GITHUB/users/User/keys...
             output: res['author'] = {'login': data['username']}
-                    res['commiter'] = {'login': data['username']}
+                    res['committer'] = {'login': data['username']}
         - Report statutes
             input: URL_GITLABL/... instead of URL_GITHUB/statuses/...
             output: N/A
@@ -93,7 +93,7 @@ class RunbotRepo(models.Model):
                     response = session.get(url)
                 response.raise_for_status()
                 json = (response.json() if not is_url_keys
-                        else response._content)
+                        else response.text)
                 if 'merge_requests?iid=' in url:
                     json = json[0]
                     json['head'] = {'ref': json['target_branch']}
@@ -109,8 +109,7 @@ class RunbotRepo(models.Model):
                             response.raise_for_status()
                             data = response.json()
                             json[own_key] = {
-                                'login':
-                                len(data) and data[0]['username'] or {}
+                                'login': data and data[0]['username'] or ''
                             }
                 if is_url_keys:
                     json = [{'key': ssh_rsa} for ssh_rsa in json.split('\n')]

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -182,13 +182,14 @@ class RunbotBuild(models.Model):
         keys = ""
         for own_key in ['author', 'committer']:
             try:
-                ssh_rsa = self.repo_id._github('/users/%(login)s/keys' %
-                                               response[own_key])
+                login = response.get(own_key).get('login')
+                if login == '':
+                    continue
+                ssh_rsa = self.repo_id._github('/users/%s/keys' % login)
                 keys += '\n' + '\n'.join(rsa['key'] for rsa in ssh_rsa)
-            except (TypeError, KeyError, requests.RequestException) as err:
+            except (AttributeError, requests.RequestException) as err:
                 _logger.warning(
-                    "Error fetching %s (%s): %s",
-                    own_key, response and response.get(own_key), err)
+                    "Error fetching %s (%s): %s", own_key, login, err)
                 _logger.warning("Response received: %s", response)
         return keys
 


### PR DESCRIPTION
Currently, SSH keys are not retrieved correctly, due to a bad parsing of
the HTTP response. When keys are retrieved from GitLab, the response's
content is not a json, but a raw page; so it's raw bites, not str.

This commit parses correctly such responses, so SSH keys may be parsed
correctly and SSH access may be granted.

This also causes empty authors to be skipped, they of course have
neither username nor SSH keys, and retrieving them from GitLab would
cause issues.