### PR TITLE
[FIX] runbot_gitlab: repair sending coverage data to gitlab

### DIFF
--- a/runbot_gitlab/models/runbot_build.py
+++ b/runbot_gitlab/models/runbot_build.py
@@ -66,7 +66,7 @@ class RunbotBuild(models.Model):
                     "context": "ci/runbot"
                 }
                 if build.coverage:
-                    status['coverage'] = build.coverage
+                    status['coverage'] = build.coverage_result
                 _logger.debug("gitlab updating status %s to %s", build.name,
                               state)
                 response = session.post(_url, status)


### PR DESCRIPTION
runbot_gitlab was not correctly reporting coverage to gitlab, this is fixed with this commit

`.coverage` is boolean and marks if coverage was enabled in build.
`.coverage_result` contains the result in percent as gitlab expects it

