### PR TITLE
[FIX] runbot_travis2docker: Stop postgresql to avoid corruption

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-travis2docker
+travis2docker==4.1.0

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -168,6 +168,9 @@ class RunbotBuild(models.Model):
                 branch_short_name, '--root-path=' + t2d_path,
                 '--exclude-after-success',
                 '--docker-image=%s' % build.repo_id.travis2docker_image,
+                # Avoid corruption of postgresql
+                '--runs-at-the-end-script=pg_isready -q && '
+                '/etc/init.d/postgresql stop'
             ]
             try:
                 path_scripts = t2d()


### PR DESCRIPTION
This is a backport of https://github.com/OCA/runbot-addons/pull/179 from 11.0

This is to be able to merge https://github.com/OCA/maintainer-quality-tools/pull/573