### PR TITLE
[REF] runbot_gitlab: Change the way GitHub icons and texts are replaced

### DIFF
--- a/runbot_gitlab/__manifest__.py
+++ b/runbot_gitlab/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["runbot"],
     "data": [
         "views/runbot_repo.xml",
+        "templates/build.xml",
         "templates/runbot_gitlab_logos.xml",
     ],
     "installable": True,

--- a/runbot_gitlab/templates/build.xml
+++ b/runbot_gitlab/templates/build.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="build_button_inherit" inherit_id="runbot.build_button">
+        <!-- Replace icon and change title: Open commit on GitHub -> GitLab -->
+        <xpath expr="//a[@aria-label='Open commit on GitHub']" position="attributes">
+            <attribute name="t-att-invisible" add="(repo.uses_gitlab and 1)" separator=" or "/>
+        </xpath>
+        <xpath expr="//a[@aria-label='Open commit on GitHub']" position="after">
+            <a t-att-invisible="not repo.uses_gitlab and 1"
+                t-attf-href="https://#{repo.base}/commit/#{bu['name']}"
+                class="btn btn-default"
+                title="Open commit on GitLab"
+                aria-label="Open commit on GitLab">
+                <i class="fa fa-gitlab"/>
+            </a>
+        </xpath>
+    </template>
+
+</odoo>

--- a/runbot_gitlab/templates/runbot_gitlab_logos.xml
+++ b/runbot_gitlab/templates/runbot_gitlab_logos.xml
@@ -3,27 +3,44 @@
     <data>
         <template id="add_gitlab_logo_in_branch_menu" inherit_id="runbot.inherits_branch_in_menu" name="Add gitlab logo in branch menu">
             <xpath expr="//i[hasclass('fa','fa-github')]" position="attributes">
-                <attribute name="t-att-class">'fa fa-gitlab' if re.uses_gitlab else 'fa fa-github'</attribute>
+                <attribute name="t-att-invisible" add="(repo.uses_gitlab and 1)" separator=" or "/>
+            </xpath>
+            <xpath expr="//i[hasclass('fa','fa-github')]" position="after">
+                <i t-att-invisible="not repo.uses_gitlab and 1" class="fa fa-gitlab"/>
             </xpath>
         </template>
         <template id="add_gitlab_logo_in_repo_view" inherit_id="runbot.repo" name="Add gitlab logo in repo view">
             <xpath expr="//i[hasclass('fa','fa-github')]" position="attributes">
-                <attribute name="t-att-class">'fa fa-gitlab' if repo.uses_gitlab else 'fa fa-github'</attribute>
+                <attribute name="t-att-invisible" add="(repo.uses_gitlab and 1)" separator=" or "/>
+            </xpath>
+            <xpath expr="//i[hasclass('fa','fa-github')]" position="after">
+                <i t-att-invisible="not repo.uses_gitlab and 1" class="fa fa-gitlab"/>
             </xpath>
         </template>
         <template id="add_gitlab_logo_in_build_button" inherit_id="runbot.build_button" name="Add gitlab logo in build button">
-            <!-- odoo only matches the first node of the expr therefore we adapt elements 1 to 4 of the expression separately -->
-            <xpath expr="(//i[hasclass('fa','fa-github')])[1]" position="attributes">
-                <attribute name="t-att-class">'fa fa-gitlab' if repo.uses_gitlab else 'fa fa-github'</attribute>
-            </xpath>
+            <!--
+            odoo only matches the first node of the expr therefore we adapt elements 2 to 4 of the expression
+            separately (1st is already covered by "Open commit on GitHub")
+            -->
             <xpath expr="(//i[hasclass('fa','fa-github')])[2]" position="attributes">
-                <attribute name="t-att-class">'fa fa-gitlab' if repo.uses_gitlab else 'fa fa-github'</attribute>
+                <attribute name="t-att-invisible" add="(repo.uses_gitlab and 1)" separator=" or "/>
             </xpath>
+            <xpath expr="(//i[hasclass('fa','fa-github')])[2]" position="after">
+                <i t-att-invisible="not repo.uses_gitlab and 1" class="fa fa-gitlab"/>
+            </xpath>
+
             <xpath expr="(//i[hasclass('fa','fa-github')])[3]" position="attributes">
-                <attribute name="t-att-class">'fa fa-gitlab' if repo.uses_gitlab else 'fa fa-github'</attribute>
+                <attribute name="t-att-invisible" add="(repo.uses_gitlab and 1)" separator=" or "/>
             </xpath>
+            <xpath expr="(//i[hasclass('fa','fa-github')])[3]" position="after">
+                <i t-att-invisible="not repo.uses_gitlab and 1" class="fa fa-gitlab"/>
+            </xpath>
+
             <xpath expr="(//i[hasclass('fa','fa-github')])[4]" position="attributes">
-                <attribute name="t-att-class">'fa fa-gitlab' if repo.uses_gitlab else 'fa fa-github'</attribute>
+                <attribute name="t-att-invisible" add="(repo.uses_gitlab and 1)" separator=" or "/>
+            </xpath>
+            <xpath expr="(//i[hasclass('fa','fa-github')])[4]" position="after">
+                <i t-att-invisible="not repo.uses_gitlab and 1" class="fa fa-gitlab"/>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
Instead of e.g.:
Inherit a GitHub icon and add a condition to replace the class by the GitLab's one in case it's a GitLab repo, or leave untouched otherwise.

Now the following is performed:
- Hide elements for GitLab repos
- Add a new element that will be visible  only for GitLab repos

This new approach makes easier to support new backends in the future (e.g. Bitbucket), because they won't cause conflicts, they would only need to follow the same approach.

In addition, not only icons are taken into account, but also the text "Open commit on GitHub".