### PR TITLE
[FIX] runbot_gitlab: to prevent exceptions with runbot addon from 1330d5209879cebc

### DIFF
--- a/runbot_gitlab/models/runbot_repo.py
+++ b/runbot_gitlab/models/runbot_repo.py
@@ -101,7 +101,17 @@ class RunbotRepo(models.Model):
                         else response.text)
                 if 'merge_requests?iid=' in url:
                     json = json[0]
-                    json['head'] = {'ref': json['target_branch']}
+
+                    json['head'] = {
+                        'ref': json['target_branch'],
+                        # github api returns a label like
+                        # 'source-project-name:source-branch-name' the closest
+                        # we got in gitlab api is
+                        # 'source_project_id:source_branch'
+                        # (without additional http/db requests)
+                        'label': '%s:%s' % (
+                            json['source_project_id'], json['source_branch']),
+                    }
                     json['base'] = {'ref': json['source_branch']}
                 if '/commits/' in url:
                     for own_key in ['author', 'committer']:


### PR DESCRIPTION
we construct a head label for gitlab as well, otherwise generating the
branch_url will throw an exception in _get_branch_url()
https://github.com/odoo/runbot/commit/1330d5209879cebc7351c5730374ddda23221678#diff-f845984e99fe832a8c029aa2d2cc8d3aR44

Info @wt-io-it