### PR TITLE
11.0 fix runbot gitlab branch infos

### DIFF
--- a/runbot_gitlab/models/runbot_repo.py
+++ b/runbot_gitlab/models/runbot_repo.py
@@ -101,7 +101,7 @@ class RunbotRepo(models.Model):
                         else response.text)
                 if 'merge_requests/' in url:
                     json['head'] = {
-                        'ref': json['target_branch'],
+                        'ref': json['source_branch'],
                         # github api returns a label like
                         # 'source-project-name:source-branch-name' the closest
                         # we got in gitlab api is
@@ -110,7 +110,7 @@ class RunbotRepo(models.Model):
                         'label': '%s:%s' % (
                             json['source_project_id'], json['source_branch']),
                     }
-                    json['base'] = {'ref': json['source_branch']}
+                    json['base'] = {'ref': json['target_branch']}
                 if '/commits/' in url:
                     for own_key in ['author', 'committer']:
                         key_email = '%s_email' % own_key

--- a/runbot_gitlab/models/runbot_repo.py
+++ b/runbot_gitlab/models/runbot_repo.py
@@ -34,7 +34,7 @@ def _get_url(url, base):
             url = url + '.keys'
         if '/pulls/' in url:
             urls = url.split('/pulls/')
-            url = urls[0] + '/merge_requests?iid=' + urls[1]
+            url = urls[0] + '/merge_requests/' + urls[1]
     return url
 
 
@@ -99,9 +99,7 @@ class RunbotRepo(models.Model):
                 response.raise_for_status()
                 json = (response.json() if not is_url_keys
                         else response.text)
-                if 'merge_requests?iid=' in url:
-                    json = json[0]
-
+                if 'merge_requests/' in url:
                     json['head'] = {
                         'ref': json['target_branch'],
                         # github api returns a label like


### PR DESCRIPTION
After some investigation on our runbot / gitlab i discovered (and fixed) some more issues in runbot_gitlab that happen after https://github.com/odoo/runbot/commit/1330d5209879cebc7351c5730374ddda23221678 introfuced the target_branch_name field

* target_branch_name is set to the actual source branch
* getting information for multiple pull requests at once only returned the information of the last pull request for all of the pull requests

Info @wt-io-it