### PR TITLE
[ADD] pin runbot to the last non-docker version

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,1 @@
-runbot https://github.com/odoo/runbot master
+runbot https://github.com/odoo/runbot pre-docker


### PR DESCRIPTION
with https://github.com/odoo/runbot/commit/4c0cd91914425a4c73494397b6f3d17c46fd0627, runbot changed drastically and we'll have to adapt all of our codebase to this.

I propose that for the time being, we pin the dependency to before docker, and for version 12, use master again.