### PR TITLE
runbot_travis2docker: fix crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ cache:
     - $HOME/.cache/pip
 
 addons:
+  postgresql: "9.6"
   apt:
     packages:
       - expect-dev  # provides unbuffer utility

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -183,9 +183,10 @@ class RunbotBuild(models.Model):
         if not response:
             return
         keys = ""
+        login = ''
         for own_key in ['author', 'committer']:
             try:
-                login = response.get(own_key).get('login')
+                login = response.get(own_key).get('login', '')
                 if login == '':
                     continue
                 ssh_rsa = self.repo_id._github('/users/%s/keys' % login)

--- a/runbot_travis2docker/models/runbot_build.py
+++ b/runbot_travis2docker/models/runbot_build.py
@@ -183,10 +183,9 @@ class RunbotBuild(models.Model):
         if not response:
             return
         keys = ""
-        login = ''
         for own_key in ['author', 'committer']:
             try:
-                login = response.get(own_key).get('login', '')
+                login = response.get(own_key, {}).get('login', '')
                 if login == '':
                     continue
                 ssh_rsa = self.repo_id._github('/users/%s/keys' % login)
@@ -194,7 +193,7 @@ class RunbotBuild(models.Model):
             except (AttributeError, requests.RequestException) as err:
                 _logger.warning(
                     "Error fetching %s (%s): %s", own_key, login, err)
-                _logger.warning("Response received: %s", response)
+                _logger.debug("Response received: %s", response)
         return keys
 
     def _schedule(self):


### PR DESCRIPTION
the the except block, we could get an error because the login variable
was used before it was assigned a value, depending on the execution path.