### PR TITLE
[ADD][runbot_buildout] improvements

### DIFF
--- a/runbot_buildout/README.rst
+++ b/runbot_buildout/README.rst
@@ -16,7 +16,7 @@ To configure this module, you need to:
 #. turn on `Use buildouts` on a repository
 #. fill in a regex that allows to differentiate a normal branch name: For runbot, branches should be named ``$version-$sometext`` anyways, so this module's suggestion is to call buildout branches ``buildout-$version-$sometext``
 #. check the value of the field `Buildout section`, this must be the name you use in your buildouts
-#. if you use multiple buildouts for the same version to implement some kind of DTAP scenario (you should), you can mark some buildout branch as the one to be used for tests by navigating to the branch and checking `Default for this version`
+#. if you use multiple buildouts for the same version to implement some kind of DTAP scenario (you should), you can mark some buildout branch as the one to be used for tests by navigating to the repository and selecting a default buildout branch. In case you deal with multiple versions, set the default to a buildout from your current version, and set the buildout branch for branches of the new version manually
 #. when converting a repository to use buildouts, be sure to remove all dependency branches first. Otherwise, runbot will copy all of them unnecessarily. Then, rebuild some buildout branch, and when it is green, rebuild another branch that is supposed to use the buildout
 
 Background

--- a/runbot_buildout/__manifest__.py
+++ b/runbot_buildout/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Buildout for runbot",
-    "version": "11.0.1.0.0",
+    "version": "11.0.1.1.0",
     "author": "Therp BV,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "category": "Runbot",

--- a/runbot_buildout/examples/buildout.cfg
+++ b/runbot_buildout/examples/buildout.cfg
@@ -10,4 +10,4 @@ anybox.recipe.odoo = 1.9.3.dev0
 [odoo]
 recipe = anybox.recipe.odoo:server
 
-version = git http://github.com/oca/ocb.git odoo 9.0 depth=1
+version = git http://github.com/oca/ocb.git odoo 11.0 depth=1

--- a/runbot_buildout/migrations/11.0.1.1.0/post-migration.py
+++ b/runbot_buildout/migrations/11.0.1.1.0/post-migration.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Therp BV <https://therp.nl>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version=None):
+    cr.execute(
+        """update runbot_repo set buildout_branch_id=runbot_branch.id
+        from runbot_branch where
+        runbot_branch.repo_id=runbot_repo.id and runbot_branch.buildout_default
+        """
+    )

--- a/runbot_buildout/models/runbot_branch.py
+++ b/runbot_buildout/models/runbot_branch.py
@@ -11,7 +11,6 @@ PYTHON3 = '/usr/bin/python3'
 class RunbotBranch(models.Model):
     _inherit = 'runbot.branch'
 
-    buildout_default = fields.Boolean('Default buildout')
     buildout_version = fields.Char(
         compute='_compute_buildout_version', store=True,
     )
@@ -22,7 +21,7 @@ class RunbotBranch(models.Model):
     )
     buildout_branch_id = fields.Many2one(
         'runbot.branch', help='Default buildout branch',
-        domain='[("repo_id", "=", repo_id)]',
+        domain="[('repo_id', '=', repo_id), ('buildout_version', '!=', False)]"
     )
 
     @api.multi

--- a/runbot_buildout/models/runbot_build.py
+++ b/runbot_buildout/models/runbot_build.py
@@ -181,7 +181,7 @@ class RunbotBuild(models.Model):
             if self._check_buildout_success(build):
                 build.write({'result': 'ok'})
                 return self._spawn(
-                    'for part in %s/*; do git -C $part repack -a --threads=1; '
+                    'for part in %s/*; do git -C $part repack -A --threads=1; '
                     'done' % (
                         build._path('parts')
                     ), lock_path, log_path, shell=True,

--- a/runbot_buildout/models/runbot_build.py
+++ b/runbot_buildout/models/runbot_build.py
@@ -286,7 +286,8 @@ class RunbotBuild(models.Model):
     @api.multi
     def _get_buildout_build(self):
         self.ensure_one()
-        buildout_branch = self.branch_id.buildout_branch_id
+        buildout_branch = self.branch_id.buildout_branch_id or\
+            self.branch_id.repo_id.buildout_branch_id
         version = None
         if not buildout_branch:
             pi = self.branch_id._get_pull_info()
@@ -296,9 +297,7 @@ class RunbotBuild(models.Model):
             buildout_branch = self.env['runbot.branch'].search([
                 ('repo_id', '=', self.repo_id.id),
                 ('buildout_version', '=', version),
-            ], order='buildout_default desc, name asc')
-            if buildout_branch.filtered('buildout_default'):
-                buildout_branch = buildout_branch.filtered('buildout_default')
+            ], order='name asc', limit=1)
         buildout_build = self.search([
             ('repo_id', '=', self.repo_id.id),
             ('state', '=', 'done'),

--- a/runbot_buildout/models/runbot_build.py
+++ b/runbot_buildout/models/runbot_build.py
@@ -408,6 +408,7 @@ class RunbotBuild(models.Model):
                 'merges =\n'
                 '    git %(target_repo)s %(path)s %(target_commit)s\n'
                 'options.logfile = False\n'
+                'options.sentry_enabled = False\n'
                 'options.log_level = info\n'
                 'options.log_handler = :INFO\n'
                 'options.workers = 0\n'

--- a/runbot_buildout/models/runbot_repo.py
+++ b/runbot_buildout/models/runbot_repo.py
@@ -20,3 +20,11 @@ class RunbotRepo(models.Model):
         default='odoo',
         help='The buildout section you use to create your odoo instance'
     )
+    buildout_branch_id = fields.Many2one(
+        'runbot.branch', 'Default buildout branch',
+        domain="[('repo_id', '=', id), ('buildout_version', '!=', False)]",
+        help='Set this to use the latest green build of this branch for '
+        'buildouts. Note you can set a specific buildout branch on branch '
+        'level too, so you should configure your testing buildout branch here,'
+        ' and configure the production buildout for your production branch.',
+    )

--- a/runbot_buildout/tests/test_runbot_buildout.py
+++ b/runbot_buildout/tests/test_runbot_buildout.py
@@ -29,11 +29,11 @@ class TestRunbotBuildout(SingleTransactionCase):
                 os.path.join(git_dir, 'buildout.cfg'), 'a'
         ) as buildout_cfg:
             buildout_cfg.write(
-                '\naddons = git %s parts/test 9.0\n' % git_dir,
+                '\naddons = git %s parts/test 11.0\n' % git_dir,
             )
 
         _git('init')
-        _git('checkout', '-b', 'buildout-9.0-testing')
+        _git('checkout', '-b', 'buildout-11.0-testing')
         _git('add', '.')
         _git('commit', '-m', 'initial commit')
 
@@ -45,7 +45,7 @@ class TestRunbotBuildout(SingleTransactionCase):
         cls.repo._update(cls.repo)
         cls.repo._scheduler(cls.repo.ids)
 
-        _git('checkout', '--orphan', '9.0')
+        _git('checkout', '--orphan', '11.0')
         _git('commit', '-m', 'initial commit')
 
     def test_00_buildout(self):

--- a/runbot_buildout/views/runbot_branch.xml
+++ b/runbot_buildout/views/runbot_branch.xml
@@ -5,7 +5,6 @@
         <field name="inherit_id" ref="runbot.branch_form" />
         <field name="arch" type="xml">
             <field name="sticky" position="after">
-                <field name="buildout_default" attrs="{'invisible': [('buildout_version', '=', False)]}" />
                 <field name="buildout_branch_id" attrs="{'invisible': [('buildout_version', '=', True)]}" />
                 <field name="buildout_section" />
             </field>

--- a/runbot_buildout/views/runbot_repo.xml
+++ b/runbot_buildout/views/runbot_repo.xml
@@ -8,6 +8,7 @@
                 <field name="uses_buildout" />
                 <field name="buildout_branch_pattern" attrs="{'invisible': [('uses_buildout', '=', False)]}" />
                 <field name="buildout_section" attrs="{'invisible': [('uses_buildout', '=', False)]}" />
+                <field name="buildout_branch_id" attrs="{'invisible': [('uses_buildout', '=', False)]}" />
             </field>
             <field name="dependency_ids" position="attributes">
                 <attribute name="attrs">{'invisible': [('uses_buildout', '=', True)]}</attribute>


### PR DESCRIPTION
- don't have a flag `buildout_default` on builds, but set a default buildout on the repo. The original was meant to support multiple versions in the same repo, but this turns out awkward and usually you only temporarily have two versions. This you can deal with with branch specific buildout branches then.
- don't git repack -a, this might drop objects we need later
- more logging
- mute sentry for all buildouts